### PR TITLE
Fixed failed assertion message

### DIFF
--- a/sechub-scan-testframework/src/main/java/com/daimler/sechub/domain/scan/AssertSecHubResult.java
+++ b/sechub-scan-testframework/src/main/java/com/daimler/sechub/domain/scan/AssertSecHubResult.java
@@ -144,7 +144,7 @@ public class AssertSecHubResult {
 			List<String> hostnamesAsList = Arrays.asList(hostnames);
 			if (!value.hostnames.containsAll(hostnamesAsList)) {
 				fail("Hostname count same, but hostnames not as expected!\nExpected: " + hostnamesAsList + "\nResulted:"
-						+ hostnames);
+						+ value.hostnames);
 			}
 
 			return this;


### PR DESCRIPTION
* referencing values.hostnames instead of variable method argument hostnames that should be identical to hostNameAsList
* finding based on [lgtm scan results](https://lgtm.com/projects/g/Daimler/sechub/snapshot/91c873adb7b33b1313458e3971ff157c16557bb2/files/sechub-scan-testframework/src/main/java/com/daimler/sechub/domain/scan/AssertSecHubResult.java?sort=name&dir=ASC&mode=heatmap#x89fd7db2580d923f:1)