### PR TITLE
Fixed flaky test + changed server behaviour, closes #160

### DIFF
--- a/sechub-schedule/src/main/java/com/daimler/sechub/domain/schedule/SchedulerUploadService.java
+++ b/sechub-schedule/src/main/java/com/daimler/sechub/domain/schedule/SchedulerUploadService.java
@@ -57,7 +57,7 @@ public class SchedulerUploadService {
 
 	@Autowired
 	UserInputAssertion assertion;
-
+	
 	@UseCaseUserUploadsSourceCode(@Step(number = 2, name = "Try to find project annd upload sourcecode as zipfile", description = "When project is found and user has access and job is initializing the sourcecode file will be uploaded"))
 	public void uploadSourceCode(String projectId, UUID jobUUID, MultipartFile file, String checkSum) {
 		assertion.isValidProjectId(projectId);

--- a/sechub-server/src/main/java/com/daimler/sechub/server/SecHubExceptionHandler.java
+++ b/sechub-server/src/main/java/com/daimler/sechub/server/SecHubExceptionHandler.java
@@ -1,0 +1,40 @@
+package com.daimler.sechub.server;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.tomcat.util.http.fileupload.FileUploadBase.SizeLimitExceededException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+
+@ControllerAdvice
+public class SecHubExceptionHandler {
+
+    @ExceptionHandler(SizeLimitExceededException.class)
+    @ResponseBody
+    public Exception handleFileUploadSizeExceeded(SizeLimitExceededException ex, HttpServletResponse response) {
+        return commonHandleFileUploadSizeExceed(ex, response);
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    @ResponseBody
+    public Exception handleFileUploadSizeExceeded(MaxUploadSizeExceededException ex, HttpServletResponse response) {
+        return commonHandleFileUploadSizeExceed(ex, response);
+    
+    }
+    
+    private Exception commonHandleFileUploadSizeExceed(Exception ex, HttpServletResponse response) {
+        if (response == null) {
+            throw new IllegalStateException("response missing");
+        }
+        if (ex == null) {
+            throw new IllegalStateException("exception missing");
+        }
+        
+        response.setStatus(HttpStatus.NOT_ACCEPTABLE.value());
+        
+        return ex;
+    }
+}

--- a/sechub-server/src/main/java/com/daimler/sechub/server/SecHubTomcatServletWebserFactory.java
+++ b/sechub-server/src/main/java/com/daimler/sechub/server/SecHubTomcatServletWebserFactory.java
@@ -1,0 +1,51 @@
+package com.daimler.sechub.server;
+
+import org.apache.catalina.connector.Connector;
+import org.apache.coyote.http11.AbstractHttp11Protocol;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.embedded.tomcat.TomcatConnectorCustomizer;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SecHubTomcatServletWebserFactory implements WebServerFactoryCustomizer<TomcatServletWebServerFactory> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SecHubTomcatServletWebserFactory.class);
+
+    @Value("${spring.servlet.multipart.max-file-size}")
+    private String maxFileSizeAsString;
+
+    @Override
+    public void customize(TomcatServletWebServerFactory factory) {
+        /* @formatter:off 
+          
+           we let Tomcat always swallow one more megabyte than spring servlet filter does
+           so we will get not SocketConnectionExceptions sometimes instad dedicated exceptions
+           as defined in SecHubExceptionHandler 
+           
+           @formatter:on*/
+        String size = maxFileSizeAsString.trim().toLowerCase();
+        if (!size.endsWith("mb")) {
+            LOG.error("Cannot customize tomcat swallow size automatically, because multipart size not supported:" + size);
+            return;
+        }
+        size = size.substring(0, size.length() - 2);
+        size = size.trim();
+
+        int springUploadMaxFileSizeInMB = Integer.parseInt(size);
+        int maxSwallowSize = (springUploadMaxFileSizeInMB + 1) * 1024 * 1024;
+
+        factory.addConnectorCustomizers(new TomcatConnectorCustomizer() {
+            @Override
+            public void customize(Connector connector) {
+                if (connector.getProtocolHandler() instanceof AbstractHttp11Protocol) {
+                    LOG.info("Set max swallow size to {}", maxSwallowSize);
+                    ((AbstractHttp11Protocol<?>) connector.getProtocolHandler()).setMaxSwallowSize(maxSwallowSize);
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
- problem was that tomcat has got a "maxswallow" configuration
  which sometimes did the connection resets and sometimes normal
  spring behaviour did throw an internal server error
- added special setup for tomcat maxswallow: Is now always 1 MB more
  than the configured spring max uploax file size
- upload exceptions now handled by SecHubExceptionHandler and switched
  to response status NOT_ACCEPTABLE
- test does now check too bigfiles return now NOT_ACCEPTABLE
- changed some minor parts inside test as well