### PR TITLE
Client: implementation of default exclude patterns #227 #260

### DIFF
--- a/sechub-cli/src/daimler.com/sechub/cli/config.go
+++ b/sechub-cli/src/daimler.com/sechub/cli/config.go
@@ -49,6 +49,7 @@ var reportFormatPtr *string
 
 /* internal stuff - only necessary for development and testing*/
 var debug = os.Getenv("SECHUB_DEBUG") == "true"
+var ignoreDefaultExcludes = os.Getenv("SECHUB_IGNORE_DEFAULT_EXCLUDES") == "true" // make it possible to switch off default excludes
 var keepTempFiles = os.Getenv("SECHUB_KEEP_TEMPFILES") == "true"
 var quiet = os.Getenv("SECHUB_QUIET") == "true"
 var trustAll = os.Getenv("SECHUB_TRUSTALL") == "true"

--- a/sechub-cli/src/daimler.com/sechub/cli/constants.go
+++ b/sechub-cli/src/daimler.com/sechub/cli/constants.go
@@ -1,9 +1,17 @@
 // SPDX-License-Identifier: MIT
+
 package cli
 
 // DefaultSecHubConfigFile represents the name of the sechub configuration file
 // used per default when no other set
 const DefaultSecHubConfigFile = "sechub.json"
+
+// DefaultZipExcludeDirPatterns - Define directory patterns to exclude from zip file:
+// code in directories named "test" is not considered to end up in the binary
+// also ignore .git directory
+var DefaultZipExcludeDirPatterns = []string{"**/test/**", "**/.git/**"}
+
+// Definition as var because a constant needs a fix array size.
 
 /* ---------------------------------- */
 /* -------- Exit codes -------------- */

--- a/sechub-cli/src/daimler.com/sechub/cli/controller.go
+++ b/sechub-cli/src/daimler.com/sechub/cli/controller.go
@@ -105,6 +105,11 @@ func handleCodeScan(context *Context) {
 	/* currently we only provide filesystem - means zipping etc. */
 	json := context.sechubConfig
 
+	// add default exclude patterns to exclude list
+	if !ignoreDefaultExcludes {
+		json.CodeScan.Excludes = append(json.CodeScan.Excludes, DefaultZipExcludeDirPatterns...)
+	}
+
 	amountOfFolders := len(json.CodeScan.FileSystem.Folders)
 	LogDebug(context, fmt.Sprintf("handleCodeScan - folders=%s", json.CodeScan.FileSystem.Folders))
 	LogDebug(context, fmt.Sprintf("handleCodeScan - excludes=%s", json.CodeScan.Excludes))

--- a/sechub-cli/src/daimler.com/sechub/util/filepathmatcher.go
+++ b/sechub-cli/src/daimler.com/sechub/util/filepathmatcher.go
@@ -3,91 +3,38 @@ package util
 
 import (
 	"fmt"
-	"path/filepath"
+	"regexp"
 	"strings"
 )
 
-//
-// This method provides ANT like selectors.
+// Filepathmatch - This method provides ANT like selectors.
+// See https://ant.apache.org/manual/dirtasks.html
 // For example: "**/a*.txt" will accept
-//               - "/home/tester/xyz/a1234.txt
-//               - "/root/a1b.txt
+//               - "/home/tester/xyz/a1234.txt"
+//               - "a1b.txt"
 //
 func Filepathmatch(path string, pattern string) (result bool) {
-	/* ------------------------------ */
-	/* Explanation - how it works ... */
-	/* ------------------------------ */
-	// - we separate pattern into different path patterns by path wildcards into elements
-	// - then the last element is inspected to be a file wildcard
-	// - file wildcards are resolved /tried by golang filepath.Match method
-	// - if this is okay we do our special path wildcard matching
 
+	// Let's turn the ant style pattern into a regexp:
+	doublestarPatterns := strings.Split(pattern, "**/")
+	//fmt.Printf("\nbefore: %q path: %q", pattern, path)
+	for i, subElement := range doublestarPatterns {
+		// esacpe . with backslash, * to .*
+		doublestarPatterns[i] = strings.Replace(strings.Replace(subElement, ".", "\\.", -1), "*", ".*", -1)
+	}
+	regexpPattern := "^" + strings.Join(doublestarPatterns, ".*/") + "$"
 
-	/* separate patterns containing path wildcards */
-	subPattern := strings.Split(pattern, "**/")
-//	fmt.Printf("\n%s - seperated into %q", pattern, subPattern)
-	length := len(subPattern)
-	potentialFilePattern := subPattern[length-1]
-
-	/* ------------------------ */
-	/* handle file name pattern */
-	/* ------------------------ */
-	substring := path
-	if strings.Index(potentialFilePattern, "*") != -1 {
-		/* found a file pattern in last entry */
-		/* change length - so slice not changed but last entry no longer handled later */
-		length--
-
-		/* check if file patter is applicable */
-		lastPathIndex := strings.LastIndex(path, "/")
-		fileName := path
-		indexForCut := lastPathIndex
-		if lastPathIndex != -1 {
-			fileName = path[lastPathIndex:]
-		} else {
-			indexForCut = 0
-		}
-		/* we just use the golang integrated filename matcher:*/
-		matches, err := filepath.Match(potentialFilePattern, fileName)
-		if err != nil {
-			fmt.Println(err)
-		}
-		if !matches {
-			return false
-		}
-
-		/* remove filename for further path inspection*/
-		substring = path[indexForCut : len(path)-indexForCut]
+	// add a './' in front of the path except it starts with a '/'
+	// so e.g. "**/.git/*" will also match the current working directory and not only subdirectories
+	if !strings.HasPrefix(path, "/") && strings.Contains(pattern, "/") {
+		path = "./" + path
 	}
 
-	/* -------------------- */
-	/* handle path patterns */
-	/* -------------------- */
-	lastOneWasAsterisk := false
-	for i := 0; i < length; i++ {
-		currentSearch := subPattern[i]
-		if currentSearch == "" {
-			/* this is double asterisk at the begining*/
-			/* so we just accept all here*/
-			lastOneWasAsterisk=true
-			continue
-		}
-		/* search for next occurrence */
-		index := strings.Index(substring, currentSearch)
-		if index == -1 {
-			/* search not found*/
-			return false
-		}
-		if !lastOneWasAsterisk && index != 0 {
-			/* found but not starting with it*/
-			/* when last pattern was not an asterisk ...*/
-			return false
-		}
-		substring = substring[index+len(currentSearch):]
-		/* after first entry we have always path asterisks between - even
-		 * when we got no longer "" between (happens only on first entry)
-		 */
-		lastOneWasAsterisk=true
+	//fmt.Printf("\n after: %q path: %q\n", regexpPattern, path)
+	matched, err := regexp.MatchString(regexpPattern, path)
+	if err != nil {
+		fmt.Println(err, matched)
 	}
-	return true
+
+	return matched
 }

--- a/sechub-cli/src/daimler.com/sechub/util/filepathmatcher.go
+++ b/sechub-cli/src/daimler.com/sechub/util/filepathmatcher.go
@@ -17,7 +17,7 @@ func Filepathmatch(path string, pattern string) (result bool) {
 
 	// Let's turn the ant style pattern into a regexp:
 	doublestarPatterns := strings.Split(pattern, "**/")
-	//fmt.Printf("\nbefore: %q path: %q", pattern, path)
+
 	for i, subElement := range doublestarPatterns {
 		// esacpe . with backslash, * to .*
 		doublestarPatterns[i] = strings.Replace(strings.Replace(subElement, ".", "\\.", -1), "*", ".*", -1)
@@ -30,7 +30,6 @@ func Filepathmatch(path string, pattern string) (result bool) {
 		path = "./" + path
 	}
 
-	//fmt.Printf("\n after: %q path: %q\n", regexpPattern, path)
 	matched, err := regexp.MatchString(regexpPattern, path)
 	if err != nil {
 		fmt.Println(err, matched)

--- a/sechub-cli/src/daimler.com/sechub/util/filepathmatcher_test.go
+++ b/sechub-cli/src/daimler.com/sechub/util/filepathmatcher_test.go
@@ -2,8 +2,9 @@
 package util
 
 import (
-	. "daimler.com/sechub/testutil"
 	"testing"
+
+	. "daimler.com/sechub/testutil"
 )
 
 func Test_Simple_filename_and_pattern_with_asterisk_at_start_and_prefix_matches(t *testing.T) {
@@ -41,6 +42,18 @@ func Test_When_double_asterisk_on_start_any_path_is_accepted_when_filename_witho
 	/* but not when filename does not match*/
 	AssertFalse(Filepathmatch("/x/y/z/V/b.txt", "**/a.txt"), t)
 	AssertFalse(Filepathmatch("/x/y/z/V/a.txt", "**/b.txt"), t)
+}
+
+func Test_When_double_asterisk_on_start_and_filename_with_asterisk(t *testing.T) {
+	AssertFalse(Filepathmatch("/x/y/z/V/a.txtx", "**/*.txt"), t)
+	AssertTrue(Filepathmatch("/x/y/z/V/b.txt", "**/*.txt"), t)
+}
+
+func Test_When_double_asterisk_also_matching_files_in_current_working_directory(t *testing.T) {
+	AssertTrue(Filepathmatch("/.git/x/y/z/V/a.txt", "**/.git/**"), t)
+	AssertTrue(Filepathmatch("/.git/a.txt", "**/.git/**"), t)
+	AssertTrue(Filepathmatch(".git/x/y/z/V/a.txt", "**/.git/**"), t)
+	AssertTrue(Filepathmatch(".git/a.txt", "**/.git/**"), t)
 }
 
 func Test_When_double_asterisk_on_inside_path_is_accepted_when_filename_without_asterisk_matches(t *testing.T) {

--- a/sechub-cli/src/daimler.com/sechub/util/zip.go
+++ b/sechub-cli/src/daimler.com/sechub/util/zip.go
@@ -25,12 +25,11 @@ type ZipConfig struct {
 	Excludes []string
 }
 
-/**
- * Will zip given content of given folders into given filePath.
- * E.g. when filePath contains subfolder sub1/text1.txt, sub2/text2.txt, sub2/sub3/text3.txt the
- * zip of sub1 and sub2 will result in "text1.txt,text2.txt,sub3/text3.txt" !
- * This is optimized for sourcecode zipping when having multiple source folders
- */
+// ZipFolders - Will zip given content of given folders into given filePath.
+// E.g. when filePath contains subfolder sub1/text1.txt, sub2/text2.txt, sub2/sub3/text3.txt the
+// zip of sub1 and sub2 will result in "text1.txt,text2.txt,sub3/text3.txt" !
+// This is optimized for sourcecode zipping when having multiple source folders
+//
 func ZipFolders(filePath string, config *ZipConfig) (err error) {
 	filename, _ := filepath.Abs(filePath)
 	/* create parent folders if not existing */
@@ -106,7 +105,7 @@ func zipOneFolderRecursively(zipWriter *zip.Writer, folder string, zContext *zip
 		/* Filter excludes */
 		for _, excludePattern := range zContext.config.Excludes {
 			if Filepathmatch(relPathFromFolder, excludePattern) {
-				//				log.Printf("Excluded: %s because of pattern:'%s'", relPathFromFolder,excludePattern)
+				//log.Printf("Excluded: %s because of pattern:'%s'", relPathFromFolder, excludePattern)
 				return nil
 			}
 		}

--- a/sechub-doc/src/docs/asciidoc/documents/shared/configuration/scan_config.adoc
+++ b/sechub-doc/src/docs/asciidoc/documents/shared/configuration/scan_config.adoc
@@ -22,7 +22,7 @@ Scan configuration can be changed by {sechub} `mapping` - look at <<mapping-tech
 NOTE: Just use the `provider` ID as mapping ID.
 
 ifdef::techdoc[]
-====== Technical details
+===== Technical details
 
 *Usage*
 

--- a/sechub-doc/src/docs/asciidoc/documents/shared/configuration/sechub_config.adoc
+++ b/sechub-doc/src/docs/asciidoc/documents/shared/configuration/sechub_config.adoc
@@ -74,12 +74,13 @@ include::sechub_config_example1_sourcescan_filesystem.json[]
 <1> Define code scan
 <2> Use filesystem - so means upload sources to server
 <3> Upload will contain sources from `gamechanger-android/src/main/java` and `gamechanger-server/src/main/java` and their sub folders
-<4> Exclude files (optional), syntax is similar to https://ant.apache.org/manual/Types/fileset.html[ANT fileset] - `+**/*+` is used to identify any folder +
-    In example above following files are excluded from upload: +
-    * `+**/*.log+` - excludes any log file in any sub directories of given folders
-    * `+README*.md+` excludes all markdown README files in given folders. For example above this means:
-      ** `gamechanger-android/src/main/java/README.md` and
-      ** `gamechanger-server/src/main/java/README.md`
+<4> Exclude directories (optional), syntax is similar to https://ant.apache.org/manual/Types/fileset.html[ANT fileset] - ` +
+    In example above all files in following directories are excluded from upload: +
+    * `+**/mytestcode/**+` - excludes all files under a directory named `build` including sub directories
+    * `+**/documentation/**+` - same for folder `documentation`
+
+NOTE: Per default, these directories are excluded so you don't have to add them yourself: +
+`+**/test/**+` `+**/.git/**+`
 
 ==== Web scan
 `webScan` (optional) defines the web scan settings.

--- a/sechub-doc/src/docs/asciidoc/documents/shared/configuration/sechub_config_example1_sourcescan_filesystem.json
+++ b/sechub-doc/src/docs/asciidoc/documents/shared/configuration/sechub_config_example1_sourcescan_filesystem.json
@@ -1,14 +1,14 @@
 {
+      "apiVersion": "1.0",
+      "server"    : "https://sechub.example.org",
 
-        "apiVersion": "1.0",
-        "server"    : "https://sechub.example.org",
+      "project"   : "gamechanger",
 
-        "project"   : "gamechanger",
-
-        "codeScan": { //<1>
-           "fileSystem": { //<2>
+      "codeScan": { //<1>
+         "fileSystem": { //<2>
               "folders": ["gamechanger-android/src/main/java",
-                          "gamechanger-server/src/main/java"], //<3>
-           "excludes"  : ["**/*.log","README*.md"]  //<4>
-        }
+                          "gamechanger-server/src/main/java"] //<3>
+         },
+         "excludes": ["**/mytestcode/**","**/documentation/**"]  //<4>
       }
+}


### PR DESCRIPTION
- implemented default exclude directory patterns
- fixed documentation's json example code (bracket was missing), example for directories, because files will be covered with #256
- re-implementation of func Filepathmatch via regexp matching which is more simple and also fixes #260
- added tests for above

closes #227 
closes #260 

---
<sup>Sven Dolderer <sven.dolderer@daimler.com>, Daimler TSS GmbH, [imprint](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md)</sup>