### PR TITLE
Made checkmarx client secret configurable + fixed some minor bugs #212

### DIFF
--- a/sechub-adapter-checkmarx/src/main/java/com/daimler/sechub/adapter/checkmarx/CheckmarxAdapterConfig.java
+++ b/sechub-adapter-checkmarx/src/main/java/com/daimler/sechub/adapter/checkmarx/CheckmarxAdapterConfig.java
@@ -21,4 +21,6 @@ public interface CheckmarxAdapterConfig extends AdapterConfig {
 
 	InputStream getSourceCodeZipFileInputStream();
 
+    String getClientSecret();
+
 }

--- a/sechub-adapter-checkmarx/src/main/java/com/daimler/sechub/adapter/checkmarx/CheckmarxConfig.java
+++ b/sechub-adapter-checkmarx/src/main/java/com/daimler/sechub/adapter/checkmarx/CheckmarxConfig.java
@@ -6,91 +6,117 @@ import java.io.InputStream;
 import com.daimler.sechub.adapter.AbstractCodeScanAdapterConfig;
 import com.daimler.sechub.adapter.AbstractCodeScanAdapterConfigBuilder;
 
-public class CheckmarxConfig extends AbstractCodeScanAdapterConfig implements CheckmarxAdapterConfig{
+public class CheckmarxConfig extends AbstractCodeScanAdapterConfig implements CheckmarxAdapterConfig {
 
-	private String teamIdForNewProjects;
-	private InputStream sourceCodeZipFileInputStream;
-	public Long presetIdForNewProjects;
+    /**
+     * This is the "client secret" is listed at <a href=
+     * "https://checkmarx.atlassian.net/wiki/spaces/KC/pages/1187774721/Using+the+CxSAST+REST+API+v8.6.0+and+up"
+     * >public Checkmarx documentation</a>
+     *
+     * Being not really a secret but just a visible constant in public space it's
+     * okay to contain this inside code.
+     */
+    public static final String DEFAULT_CLIENT_SECRET = "014DF517-39D1-4453-B7B3-9930C563627C";
 
-	private CheckmarxConfig() {
-	}
+    private String teamIdForNewProjects;
+    private InputStream sourceCodeZipFileInputStream;
+    public Long presetIdForNewProjects;
+    private String clientSecret;// client secret just ensures it is a checkmarx instance - we use default value,
+                                // but we make it configurable if this changes ever in future
 
-	@Override
-	public String getTeamIdForNewProjects() {
-		return teamIdForNewProjects;
-	}
+    private CheckmarxConfig() {
+    }
 
-	public Long getPresetIdForNewProjectsOrNull() {
-		return presetIdForNewProjects;
-	}
+    @Override
+    public String getTeamIdForNewProjects() {
+        return teamIdForNewProjects;
+    }
 
-	@Override
-	public InputStream getSourceCodeZipFileInputStream() {
-		return sourceCodeZipFileInputStream;
-	}
+    @Override
+    public String getClientSecret() {
+        return clientSecret;
+    }
 
-	public static CheckmarxConfigBuilder builder() {
-		return new CheckmarxConfigBuilder();
-	}
+    public Long getPresetIdForNewProjectsOrNull() {
+        return presetIdForNewProjects;
+    }
 
-	public static class CheckmarxConfigBuilder extends AbstractCodeScanAdapterConfigBuilder<CheckmarxConfigBuilder, CheckmarxConfig>{
+    @Override
+    public InputStream getSourceCodeZipFileInputStream() {
+        return sourceCodeZipFileInputStream;
+    }
 
-		private String teamIdForNewProjects;
-		private Long presetIdForNewProjects;
-		private InputStream sourceCodeZipFileInputStream;
+    public static CheckmarxConfigBuilder builder() {
+        return new CheckmarxConfigBuilder();
+    }
 
-		/**
-		 * When we create a new project this is the team ID to use
-		 * @param teamId
-		 * @return
-		 */
-		public CheckmarxConfigBuilder setTeamIdForNewProjects(String teamId){
-			this.teamIdForNewProjects=teamId;
-			return this;
-		}
+    public static class CheckmarxConfigBuilder extends AbstractCodeScanAdapterConfigBuilder<CheckmarxConfigBuilder, CheckmarxConfig> {
 
-		/**
-		 * When we create a new project this is the team ID to use
-		 * @param teamId
-		 * @return
-		 */
-		public CheckmarxConfigBuilder setPresetIdForNewProjects(Long presetId){
-			this.presetIdForNewProjects=presetId;
-			return this;
-		}
+        private String teamIdForNewProjects;
+        private Long presetIdForNewProjects;
+        private InputStream sourceCodeZipFileInputStream;
+        
+        private String clientSecret = DEFAULT_CLIENT_SECRET; // per default use default client secret
 
-		public CheckmarxConfigBuilder setSourceCodeZipFileInputStream(InputStream sourceCodeZipFileInputStream){
-			this.sourceCodeZipFileInputStream=sourceCodeZipFileInputStream;
-			return this;
-		}
+        /**
+         * When we create a new project this is the team ID to use
+         * 
+         * @param teamId
+         * @return
+         */
+        public CheckmarxConfigBuilder setTeamIdForNewProjects(String teamId) {
+            this.teamIdForNewProjects = teamId;
+            return this;
+        }
 
-		@Override
-		protected void customBuild(CheckmarxConfig config) {
-			config.teamIdForNewProjects=teamIdForNewProjects;
-			config.presetIdForNewProjects=presetIdForNewProjects;
-			config.sourceCodeZipFileInputStream=sourceCodeZipFileInputStream;
-		}
+        public CheckmarxConfigBuilder setClientSecret(String newClientSecret) {
+            this.clientSecret = newClientSecret;
+            return this;
+        }
 
-		@Override
-		protected CheckmarxConfig buildInitialConfig() {
-			return new CheckmarxConfig();
-		}
+        /**
+         * When we create a new project this is the team ID to use
+         * 
+         * @param teamId
+         * @return
+         */
+        public CheckmarxConfigBuilder setPresetIdForNewProjects(Long presetId) {
+            this.presetIdForNewProjects = presetId;
+            return this;
+        }
 
-		@Override
-		protected void customValidate() {
-			assertUserSet();
-			assertPasswordSet();
-			assertProjectIdSet();
-			assertTeamIdSet();
-		}
+        public CheckmarxConfigBuilder setSourceCodeZipFileInputStream(InputStream sourceCodeZipFileInputStream) {
+            this.sourceCodeZipFileInputStream = sourceCodeZipFileInputStream;
+            return this;
+        }
 
-		protected void assertTeamIdSet() {
-			if (teamIdForNewProjects == null) {
-				throw new IllegalStateException("no team id given");
-			}
-		}
+        @Override
+        protected void customBuild(CheckmarxConfig config) {
+            config.teamIdForNewProjects = teamIdForNewProjects;
+            config.presetIdForNewProjects = presetIdForNewProjects;
+            config.sourceCodeZipFileInputStream = sourceCodeZipFileInputStream;
+            config.clientSecret = clientSecret;
+        }
 
-	}
+        @Override
+        protected CheckmarxConfig buildInitialConfig() {
+            return new CheckmarxConfig();
+        }
 
+        @Override
+        protected void customValidate() {
+            assertUserSet();
+            assertPasswordSet();
+            assertProjectIdSet();
+            assertTeamIdSet();
+        }
+
+        protected void assertTeamIdSet() {
+            if (teamIdForNewProjects == null) {
+                throw new IllegalStateException("no team id given");
+            }
+        }
+
+    }
 
 }

--- a/sechub-adapter-checkmarx/src/main/java/com/daimler/sechub/adapter/checkmarx/MockedCheckmarxAdapter.java
+++ b/sechub-adapter-checkmarx/src/main/java/com/daimler/sechub/adapter/checkmarx/MockedCheckmarxAdapter.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 package com.daimler.sechub.adapter.checkmarx;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
@@ -10,7 +11,11 @@ import com.daimler.sechub.adapter.mock.AbstractMockedAdapter;
 @Profile(AdapterProfiles.MOCKED_PRODUCTS)
 @Component
 public class MockedCheckmarxAdapter extends AbstractMockedAdapter<CheckmarxAdapterContext, CheckmarxAdapterConfig> implements CheckmarxAdapter {
+    
+    @Value("${sechub.adapter.checkmarx.clientsecret:"+CheckmarxConfig.DEFAULT_CLIENT_SECRET+"}")
+    private String clientSecret;
 
+    
 	/**
 	 * Check config data is as written in yaml file! This will check that all params
 	 * are really given to the mock - means e.g. no data missing or accidently using
@@ -18,22 +23,26 @@ public class MockedCheckmarxAdapter extends AbstractMockedAdapter<CheckmarxAdapt
 	 *
 	 * @param config
 	 */
-	protected void validateConfigAsDefinedInMockYAML(CheckmarxAdapterConfig config) {
-		if (! isMockSanityCheckEnabled()) {
-			return;
-		}
+	protected void executeMockSanityCheck(CheckmarxAdapterConfig config) {
 		/*
 		 * the token is for the apiToken'nessus-api-token' and user id
 		 * 'nessus-user-id' from application-mock.yml!
 		 */
 		if (!"checkmarx-password".equals(config.getPasswordOrAPIToken())) {
-			throw new IllegalArgumentException(config.getPasswordOrAPIToken());
+		    handleSanityFailure("checkmarx config password:"+config.getPasswordOrAPIToken());
 		}
+		if (clientSecret==null) {
+		    handleSanityFailure("client secret not set in in environment!");
+		}
+		if (! clientSecret.equals(config.getClientSecret())) {
+		    handleSanityFailure("client secret not set correctly! Expected:"+clientSecret+", but got:"+config.getClientSecret());
+		}
+		
 		String productBaseURL = config.getProductBaseURL();
 
 		boolean baseURLAsExpected = "https://checkmarx.mock.example.org:6011".equals(productBaseURL);
 		if (!baseURLAsExpected) {
-			throw new IllegalArgumentException("Checkmarx base url not as expected:" + productBaseURL);
+		    handleSanityFailure("Checkmarx base url not as expected:" + productBaseURL);
 		}
 	}
 

--- a/sechub-adapter-checkmarx/src/main/java/com/daimler/sechub/adapter/checkmarx/support/CheckmarxOAuthSupport.java
+++ b/sechub-adapter-checkmarx/src/main/java/com/daimler/sechub/adapter/checkmarx/support/CheckmarxOAuthSupport.java
@@ -37,7 +37,7 @@ public class CheckmarxOAuthSupport {
 		map.add("grant_type", "password");
 		map.add("scope", "sast_rest_api");
 		map.add("client_id", "resource_owner_client");
-		map.add("client_secret", "014DF517-39D1-4453-B7B3-9930C563627C"); // client secret just ensures it is a checkmarx instance - so public...
+		map.add("client_secret", config.getClientSecret()); 
 
 		HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(map, headers);
 

--- a/sechub-adapter-checkmarx/src/test/java/com/daimler/sechub/adapter/checkmarx/CheckmarxAdapterV1WireMockTest.java
+++ b/sechub-adapter-checkmarx/src/test/java/com/daimler/sechub/adapter/checkmarx/CheckmarxAdapterV1WireMockTest.java
@@ -87,6 +87,7 @@ public class CheckmarxAdapterV1WireMockTest {
         
         when(config.getTraceID()).thenReturn(SECHUB_TRACE_ID);
         when(config.getPresetIdForNewProjectsOrNull()).thenReturn(CHECKMARX_SECHUB_DEFAULT_PRESET_ID);
+        when(config.getClientSecret()).thenReturn(CheckmarxConfig.DEFAULT_CLIENT_SECRET);
         when(config.getUser()).thenReturn(USERNAME);
         when(config.getTargetType()).thenReturn(TARGET_TYPE);
         when(config.getPasswordOrAPIToken()).thenReturn(PASSWORD);
@@ -426,7 +427,7 @@ public class CheckmarxAdapterV1WireMockTest {
            map.put("grant_type", "password");
            map.put("scope", "sast_rest_api");
            map.put("client_id", "resource_owner_client");
-           map.put("client_secret", "014DF517-39D1-4453-B7B3-9930C563627C"); // TODO maybe this must be customizable
+           map.put("client_secret", CheckmarxConfig.DEFAULT_CLIENT_SECRET); 
 
            
 

--- a/sechub-adapter-checkmarx/src/test/java/com/daimler/sechub/adapter/checkmarx/CheckmarxConfigTest.java
+++ b/sechub-adapter-checkmarx/src/test/java/com/daimler/sechub/adapter/checkmarx/CheckmarxConfigTest.java
@@ -1,0 +1,46 @@
+package com.daimler.sechub.adapter.checkmarx;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import com.daimler.sechub.adapter.checkmarx.CheckmarxConfig.CheckmarxConfigBuilder;
+
+public class CheckmarxConfigTest {
+
+    @Test
+    public void builder_creates_config_with_default_client_secret_when_not_set() {
+        /* prepare */
+        CheckmarxConfigBuilder builder = createBuilderWithMandatoryParamatersSet();
+
+        /* execute */
+        CheckmarxConfig config = builder.build();
+
+        /* test */
+        assertEquals(CheckmarxConfig.DEFAULT_CLIENT_SECRET, config.getClientSecret());
+    }
+
+    @Test
+    public void builder_creates_config_with_given_client_secret_when_set() {
+        /* prepare */
+        String newSecret = "test-secret";
+        CheckmarxConfigBuilder builder = createBuilderWithMandatoryParamatersSet();
+        builder.setClientSecret(newSecret);
+
+        /* execute */
+        CheckmarxConfig config = builder.build();
+
+        /* test */
+        assertEquals(newSecret, config.getClientSecret());
+    }
+
+    private CheckmarxConfigBuilder createBuilderWithMandatoryParamatersSet() {
+        CheckmarxConfigBuilder builder = CheckmarxConfig.builder();
+        builder.setUser("testuserId");
+        builder.setPasswordOrAPIToken("testapitoken");
+        builder.setProjectId("testprojectid");
+        builder.setTeamIdForNewProjects("testteamid");
+        return builder;
+    }
+
+}

--- a/sechub-adapter-nessus/src/main/java/com/daimler/sechub/adapter/nessus/MockedNessusAdapter.java
+++ b/sechub-adapter-nessus/src/main/java/com/daimler/sechub/adapter/nessus/MockedNessusAdapter.java
@@ -12,23 +12,23 @@ import com.daimler.sechub.adapter.mock.MockedAdapter;
 @Component
 public class MockedNessusAdapter extends AbstractMockedAdapter<NessusAdapterContext, NessusAdapterConfig> implements NessusAdapter, MockedAdapter<NessusAdapterConfig> {
 
-	protected void validateConfigAsDefinedInMockYAML(NessusAdapterConfig config) {
+	protected void executeMockSanityCheck(NessusAdapterConfig config) {
 		/*
 		 * the token is for the apiToken'nessus-api-token' and user id
 		 * 'nessus-user-id' from application-mock.yml!
 		 */
 		if (!"nessus-password".equals(config.getPasswordOrAPIToken())) {
-			throw new IllegalArgumentException(config.getPasswordOrAPIToken());
+		    handleSanityFailure("api token not as expected:"+config.getPasswordOrAPIToken());
 		}
 		if (!"nessus-default-policiy-id".equals(config.getPolicyId())) {
-			throw new IllegalArgumentException("Nessus policy not as expected:" + config.getPolicyId());
+		    handleSanityFailure("Nessus policy not as expected:" + config.getPolicyId());
 		}
 		String productBaseURL = config.getProductBaseURL();
 
 		boolean baseURLAsExpected = "https://nessus-intranet.mock.example.org:6000".equals(productBaseURL);
 		baseURLAsExpected= baseURLAsExpected || "https://nessus-internet.mock.example.org.com:6000".equals(productBaseURL);
 		if (!baseURLAsExpected) {
-			throw new IllegalArgumentException("Nessus base url not as expected:" + productBaseURL);
+		    handleSanityFailure("Nessus base url not as expected:" + productBaseURL);
 		}
 	}
 	

--- a/sechub-adapter-netsparker/src/main/java/com/daimler/sechub/adapter/netsparker/MockedNetsparkerAdapter.java
+++ b/sechub-adapter-netsparker/src/main/java/com/daimler/sechub/adapter/netsparker/MockedNetsparkerAdapter.java
@@ -13,7 +13,7 @@ public class MockedNetsparkerAdapter extends AbstractMockedAdapter<NetsparkerAda
 		implements NetsparkerAdapter {
 
 
-	protected void validateConfigAsDefinedInMockYAML(NetsparkerAdapterConfig config) {
+	protected void executeMockSanityCheck(NetsparkerAdapterConfig config) {
 		String productBaseURL = config.getProductBaseURL();
 		boolean baseURLAsExpected = "https://netsparker.mock.example.org:4000".equals(productBaseURL);
 		if (!baseURLAsExpected) {
@@ -24,19 +24,19 @@ public class MockedNetsparkerAdapter extends AbstractMockedAdapter<NetsparkerAda
 		 * 'netsparker-user-id' from application-mock.yml!
 		 */
 		if (!"bmV0c3Bhcmtlci11c2VyLWlkOm5ldHNwYXJrZXItYXBpLXRva2Vu".equals(config.getPasswordOrAPITokenBase64Encoded())) {
-			throw new IllegalArgumentException(config.getPasswordOrAPITokenBase64Encoded());
+		    handleSanityFailure("pwd not as expected"+config.getPasswordOrAPITokenBase64Encoded());
 		}
 		if (!"netsparker-default-policiy-id".equals(config.getPolicyId())) {
-			throw new IllegalArgumentException("Netsparker policy not as expected:" + config.getPolicyId());
+		    handleSanityFailure("Netsparker policy not as expected:" + config.getPolicyId());
 		}
 		if (!"netsparker-license-id".equals(config.getLicenseID())) {
-			throw new IllegalArgumentException("netsparker-license-id not as expected:" + config.getLicenseID());
+		    handleSanityFailure("netsparker-license-id not as expected:" + config.getLicenseID());
 		}
 		String agentGroupName = config.getAgentGroupName();
 		boolean agentGroupAsExpected = "netsparker-agent-group-intranet".equals(agentGroupName);
 		agentGroupAsExpected = agentGroupAsExpected || "netsparker-agent-group-internet".equals(agentGroupName);
 		if (!agentGroupAsExpected) {
-			throw new IllegalArgumentException("netsparker agent group name not found but:" + agentGroupName);
+		    handleSanityFailure("netsparker agent group name not found but:" + agentGroupName);
 		}
 	}
 	

--- a/sechub-adapter-pds/src/main/java/com/daimler/sechub/adapter/pds/MockedPDSAdapter.java
+++ b/sechub-adapter-pds/src/main/java/com/daimler/sechub/adapter/pds/MockedPDSAdapter.java
@@ -13,7 +13,7 @@ public class MockedPDSAdapter extends AbstractMockedAdapter<PDSAdapterContext, P
 		implements PDSAdapter {
 
 
-	protected void validateConfigAsDefinedInMockYAML(PDSAdapterConfig config) {
+	protected void executeMockSanityCheck(PDSAdapterConfig config) {
 	}
 	
 	@Override

--- a/sechub-adapter/src/main/java/com/daimler/sechub/adapter/mock/MockedAdapter.java
+++ b/sechub-adapter/src/main/java/com/daimler/sechub/adapter/mock/MockedAdapter.java
@@ -11,14 +11,4 @@ import com.daimler.sechub.adapter.AdapterConfig;
  */
 public interface MockedAdapter<C extends AdapterConfig> extends Adapter<C>{
 
-	/**
-	 * For some stages (e.g. test) a sanity check can be enabled to check parameters
-	 * are as expected. So config builder etc. can be tested.
-	 * But for environments where those variable are set on deployment (e.g. kubernetes
-	 * this is normally a problem and should not be turned on)
-	 * @return
-	 */
-	public default boolean isMockSanityCheckEnabled() {
-		return Boolean.getBoolean("sechub.adapter.mock.sanitycheck.enabled");
-	}
 }

--- a/sechub-adapter/src/test/java/com/daimler/sechub/adapter/mock/AbstractMockedAdapterTest.java
+++ b/sechub-adapter/src/test/java/com/daimler/sechub/adapter/mock/AbstractMockedAdapterTest.java
@@ -12,7 +12,6 @@ public class AbstractMockedAdapterTest {
 
 	private TestAbstractMockedAdapter testAdapter;
 
-
 	@Before
 	public void before() {
 		testAdapter = new TestAbstractMockedAdapter();
@@ -39,10 +38,6 @@ public class AbstractMockedAdapterTest {
 		private String fileEnding;
 		
 		@Override
-		protected void validateConfigAsDefinedInMockYAML(AdapterConfig config) {
-			// not necessary
-		}
-		@Override
 		protected String getMockDataFileEnding() {
 			if (fileEnding!=null) {
 				return fileEnding;
@@ -53,6 +48,10 @@ public class AbstractMockedAdapterTest {
 		public int getAdapterVersion() {
 			return 10;
 		}
+        @Override
+        protected void executeMockSanityCheck(AdapterConfig config) {
+            // not necessary
+        }
 		
 	}
 }

--- a/sechub-scan-product-checkmarx/src/main/java/com/daimler/sechub/domain/scan/product/checkmarx/CheckmarxInstallSetup.java
+++ b/sechub-scan-product-checkmarx/src/main/java/com/daimler/sechub/domain/scan/product/checkmarx/CheckmarxInstallSetup.java
@@ -18,5 +18,11 @@ public interface CheckmarxInstallSetup extends AnyTargetOneInstallSetup{
 	 * @return preset Id or <code>null</code> - in case of null checkmarx will use default preset
 	 */
 	public Long getPresetIdForNewProjects(String projectId);
+	
+	/**
+	 * Get 'client secret' value
+	 * @return
+	 */
+	public String getClientSecret();
 
 }

--- a/sechub-scan-product-checkmarx/src/main/java/com/daimler/sechub/domain/scan/product/checkmarx/CheckmarxInstallSetupImpl.java
+++ b/sechub-scan-product-checkmarx/src/main/java/com/daimler/sechub/domain/scan/product/checkmarx/CheckmarxInstallSetupImpl.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.daimler.sechub.adapter.AbstractAdapterConfigBuilder;
+import com.daimler.sechub.adapter.checkmarx.CheckmarxConfig;
 import com.daimler.sechub.domain.scan.AbstractInstallSetup;
 import com.daimler.sechub.domain.scan.TargetType;
 import com.daimler.sechub.domain.scan.config.ScanConfigService;
@@ -38,6 +39,10 @@ public class CheckmarxInstallSetupImpl extends AbstractInstallSetup implements C
 	@Value("${sechub.adapter.checkmarx.password}")
 	@MustBeDocumented(value = "Password of checkmarx user", secret = true)
 	private String password;
+	
+	@Value("${sechub.adapter.checkmarx.clientsecret:"+CheckmarxConfig.DEFAULT_CLIENT_SECRET+"}")
+    @MustBeDocumented(value = "So called 'client secret' of checkmarx. At leat at the moment this ist just a fixed default value, available in public documentation at https://checkmarx.atlassian.net/wiki/spaces/KC/pages/1187774721/Using+the+CxSAST+REST+API+v8.6.0+and+up", secret = false)
+    private String clientSecret = CheckmarxConfig.DEFAULT_CLIENT_SECRET;
 
 	@Value("${sechub.adapter.checkmarx.trustall:false}")
 	@MustBeDocumented(AbstractAdapterConfigBuilder.DOCUMENT_INFO_TRUSTALL)
@@ -50,6 +55,10 @@ public class CheckmarxInstallSetupImpl extends AbstractInstallSetup implements C
 	public String getBaseURL() {
 		return baseURL;
 	}
+	
+	public String getClientSecret() {
+        return clientSecret;
+    }
 
 	@Override
 	public String getUserId() {

--- a/sechub-scan-product-checkmarx/src/main/java/com/daimler/sechub/domain/scan/product/checkmarx/CheckmarxProductExecutor.java
+++ b/sechub-scan-product-checkmarx/src/main/java/com/daimler/sechub/domain/scan/product/checkmarx/CheckmarxProductExecutor.java
@@ -101,6 +101,7 @@ public class CheckmarxProductExecutor extends AbstractCodeScanProductExecutor<Ch
 							setFileSystemSourceFolders(data.getCodeUploadFileSystemFolders()).
 							setSourceCodeZipFileInputStream(sourceCodeZipFileInputStream).
 							setTeamIdForNewProjects(setup.getTeamIdForNewProjects(projectId)).
+							setClientSecret(setup.getClientSecret()).
 							setPresetIdForNewProjects(setup.getPresetIdForNewProjects(projectId)).
 							setProjectId(projectId).
 							setTraceID(context.getTraceLogIdAsString()).

--- a/sechub-scan-product-checkmarx/src/test/java/com/daimler/sechub/domain/scan/product/checkmarx/CheckmarxProductExecutorMockTest.java
+++ b/sechub-scan-product-checkmarx/src/test/java/com/daimler/sechub/domain/scan/product/checkmarx/CheckmarxProductExecutorMockTest.java
@@ -41,6 +41,7 @@ public class CheckmarxProductExecutorMockTest {
 	@MockBean
 	TargetResolver targetResolver;
 
+
 	@Before
 	public void before() {
 	}
@@ -49,6 +50,7 @@ public class CheckmarxProductExecutorMockTest {
 	public void action_executor_contains_checkmarx_resilience_consultant_after_postConstruct() {
 		assertTrue(executorToTest.resilientActionExecutor.containsConsultant(CheckmarxResilienceConsultant.class));
 	}
+	
 
 
 	@TestConfiguration


### PR DESCRIPTION
- sanity check inside mocks does now work again (was not
  executed before this commit, because not using spring boot values
  to check if sanity check was enabled)
- added some junit tests for config
- added mock sanity check methdo for checkmarx client secret

---
<sup>Albert Tregnaghi <albert.tregnaghi@daimler.com>, Daimler TSS GmbH, [imprint](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md)</sup>