### PR TITLE
Changed MDC logging #293

### DIFF
--- a/sechub-scan-product-sereco/src/main/java/com/daimler/sechub/domain/scan/product/sereco/SerecoReportProductExecutor.java
+++ b/sechub-scan-product-sereco/src/main/java/com/daimler/sechub/domain/scan/product/sereco/SerecoReportProductExecutor.java
@@ -10,7 +10,6 @@ import java.util.UUID;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -21,7 +20,6 @@ import com.daimler.sechub.domain.scan.product.ProductResultRepository;
 import com.daimler.sechub.domain.scan.report.ScanReportProductExecutor;
 import com.daimler.sechub.sereco.Sereco;
 import com.daimler.sechub.sereco.Workspace;
-import com.daimler.sechub.sharedkernel.LogConstants;
 import com.daimler.sechub.sharedkernel.UUIDTraceLogID;
 import com.daimler.sechub.sharedkernel.execution.SecHubExecutionContext;
 import com.daimler.sechub.sharedkernel.execution.SecHubExecutionException;
@@ -57,8 +55,6 @@ public class SerecoReportProductExecutor implements ScanReportProductExecutor {
 		UUID secHubJobUUID = context.getSechubJobUUID();
 		UUIDTraceLogID traceLogId = UUIDTraceLogID.traceLogID(secHubJobUUID);
 
-		MDC.put(LogConstants.MDC_SECHUB_PROJECT_ID, projectId);
-		MDC.put(LogConstants.MDC_SECHUB_JOB_UUID, traceLogId.getPlainId());
 		LOG.debug("{} start sereco execution", traceLogId);
 
 		/* load the results by job uuid */

--- a/sechub-scan/src/main/java/com/daimler/sechub/domain/scan/ScanService.java
+++ b/sechub-scan/src/main/java/com/daimler/sechub/domain/scan/ScanService.java
@@ -10,7 +10,6 @@ import java.util.UUID;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -27,7 +26,6 @@ import com.daimler.sechub.domain.scan.project.ScanProjectMockDataConfiguration;
 import com.daimler.sechub.domain.scan.report.CreateScanReportService;
 import com.daimler.sechub.domain.scan.report.ScanReport;
 import com.daimler.sechub.domain.scan.report.ScanReportException;
-import com.daimler.sechub.sharedkernel.LogConstants;
 import com.daimler.sechub.sharedkernel.MustBeDocumented;
 import com.daimler.sechub.sharedkernel.ProgressMonitor;
 import com.daimler.sechub.sharedkernel.configuration.SecHubConfiguration;
@@ -139,7 +137,6 @@ public class ScanService implements SynchronMessageHandler {
 
     protected void executeScan(SecHubExecutionContext context, DomainMessage request) throws SecHubExecutionException {
         DomainDataTraceLogID sechubJobUUID = traceLogID(request);
-        MDC.put(LogConstants.MDC_SECHUB_JOB_UUID, sechubJobUUID.getPlainId());
 
         LOG.info("start scan for {}", sechubJobUUID);
 

--- a/sechub-schedule/src/main/java/com/daimler/sechub/domain/schedule/SchedulerApproveJobService.java
+++ b/sechub-schedule/src/main/java/com/daimler/sechub/domain/schedule/SchedulerApproveJobService.java
@@ -5,13 +5,11 @@ import java.util.UUID;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.daimler.sechub.domain.schedule.job.ScheduleSecHubJob;
 import com.daimler.sechub.domain.schedule.job.SecHubJobRepository;
-import com.daimler.sechub.sharedkernel.LogConstants;
 import com.daimler.sechub.sharedkernel.Step;
 import com.daimler.sechub.sharedkernel.error.NotAcceptableException;
 import com.daimler.sechub.sharedkernel.usecases.user.execute.UseCaseUserApprovesJob;
@@ -46,7 +44,6 @@ public class SchedulerApproveJobService {
 		secHubJob.setExecutionState(ExecutionState.READY_TO_START);
 		jobRepository.save(secHubJob);
 
-		MDC.put(LogConstants.MDC_SECHUB_JOB_UUID, jobUUID.toString());
 		LOG.info("job {} now approved", jobUUID);
 	}
 

--- a/sechub-schedule/src/main/java/com/daimler/sechub/domain/schedule/SchedulerCancelJobService.java
+++ b/sechub-schedule/src/main/java/com/daimler/sechub/domain/schedule/SchedulerCancelJobService.java
@@ -7,7 +7,6 @@ import java.util.UUID;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
 import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.launch.JobOperator;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,7 +16,6 @@ import org.springframework.stereotype.Service;
 import com.daimler.sechub.domain.schedule.batch.SchedulerCancelBatchJobService;
 import com.daimler.sechub.domain.schedule.job.ScheduleSecHubJob;
 import com.daimler.sechub.domain.schedule.job.SecHubJobRepository;
-import com.daimler.sechub.sharedkernel.LogConstants;
 import com.daimler.sechub.sharedkernel.Step;
 import com.daimler.sechub.sharedkernel.error.NotAcceptableException;
 import com.daimler.sechub.sharedkernel.messaging.DomainMessage;
@@ -78,7 +76,6 @@ public class SchedulerCancelJobService {
         cancelBatchJobService.stopAllRunningBatchJobsForSechubJobUUID(jobUUID);
         markJobAsCanceled(secHubJob);
 
-        MDC.put(LogConstants.MDC_SECHUB_JOB_UUID, jobUUID.toString());
         LOG.info("job {} has been canceled", jobUUID);
 
         sendJobCanceled(secHubJob, ownerEmailAddress);

--- a/sechub-schedule/src/main/java/com/daimler/sechub/domain/schedule/SchedulerCreateJobService.java
+++ b/sechub-schedule/src/main/java/com/daimler/sechub/domain/schedule/SchedulerCreateJobService.java
@@ -7,7 +7,6 @@ import javax.validation.Valid;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
@@ -16,7 +15,6 @@ import com.daimler.sechub.domain.schedule.job.ScheduleSecHubJob;
 import com.daimler.sechub.domain.schedule.job.SecHubJobFactory;
 import com.daimler.sechub.domain.schedule.job.SecHubJobRepository;
 import com.daimler.sechub.domain.schedule.job.SecHubJobTraceLogID;
-import com.daimler.sechub.sharedkernel.LogConstants;
 import com.daimler.sechub.sharedkernel.Step;
 import com.daimler.sechub.sharedkernel.configuration.SecHubConfiguration;
 import com.daimler.sechub.sharedkernel.usecases.user.execute.UseCaseUserCreatesNewJob;
@@ -54,7 +52,6 @@ public class SchedulerCreateJobService {
 		jobRepository.save(secHubJob);
 
 		SecHubJobTraceLogID traceLogId = traceLogID(secHubJob);
-		MDC.put(LogConstants.MDC_SECHUB_JOB_UUID, traceLogId.getPlainId());
 		LOG.info("New job added:{}", traceLogId);
 		return new SchedulerResult(secHubJob.getUUID());
 	}

--- a/sechub-schedule/src/main/java/com/daimler/sechub/domain/schedule/SchedulerRestartJobService.java
+++ b/sechub-schedule/src/main/java/com/daimler/sechub/domain/schedule/SchedulerRestartJobService.java
@@ -7,7 +7,6 @@ import java.util.UUID;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
@@ -15,7 +14,6 @@ import org.springframework.stereotype.Service;
 import com.daimler.sechub.domain.schedule.batch.SchedulerCancelBatchJobService;
 import com.daimler.sechub.domain.schedule.job.ScheduleSecHubJob;
 import com.daimler.sechub.domain.schedule.job.SecHubJobRepository;
-import com.daimler.sechub.sharedkernel.LogConstants;
 import com.daimler.sechub.sharedkernel.SecHubEnvironment;
 import com.daimler.sechub.sharedkernel.Step;
 import com.daimler.sechub.sharedkernel.error.AlreadyExistsException;
@@ -125,9 +123,6 @@ public class SchedulerRestartJobService {
         if (hard) {
             sendPurgeJobResultsSynchronousRequest(job);
         }
-
-
-        MDC.put(LogConstants.MDC_SECHUB_JOB_UUID, jobUUID.toString());
 
         ScheduleSecHubJob secHubJob = optJob.get();
         markJobAsNewExecutedNow(secHubJob);

--- a/sechub-schedule/src/main/java/com/daimler/sechub/domain/schedule/SchedulerUploadService.java
+++ b/sechub-schedule/src/main/java/com/daimler/sechub/domain/schedule/SchedulerUploadService.java
@@ -10,13 +10,11 @@ import java.util.UUID;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.daimler.sechub.domain.schedule.job.ScheduleSecHubJob;
-import com.daimler.sechub.sharedkernel.LogConstants;
 import com.daimler.sechub.sharedkernel.Step;
 import com.daimler.sechub.sharedkernel.UUIDTraceLogID;
 import com.daimler.sechub.sharedkernel.error.NotAcceptableException;
@@ -63,9 +61,6 @@ public class SchedulerUploadService {
 		assertion.isValidProjectId(projectId);
 		assertion.isValidJobUUID(jobUUID);
 		notNull(file, "file may not be null!");
-
-		MDC.put(LogConstants.MDC_SECHUB_JOB_UUID, jobUUID.toString());
-		MDC.put(LogConstants.MDC_SECHUB_PROJECT_ID, projectId);
 
 		String traceLogID = logSanitizer.sanitize(UUIDTraceLogID.traceLogID(jobUUID),-1);
 

--- a/sechub-server/src/main/java/com/daimler/sechub/server/SecHubServerMDCAsyncHandlerInterceptor.java
+++ b/sechub-server/src/main/java/com/daimler/sechub/server/SecHubServerMDCAsyncHandlerInterceptor.java
@@ -1,0 +1,92 @@
+package com.daimler.sechub.server;
+
+import java.util.UUID;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+
+import com.daimler.sechub.sharedkernel.APIConstants;
+import com.daimler.sechub.sharedkernel.LogConstants;
+
+public class SecHubServerMDCAsyncHandlerInterceptor extends HandlerInterceptorAdapter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SecHubServerMDCAsyncHandlerInterceptor.class);
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        LOG.trace("Initial clearing MDC for asynchronous request");
+        // we clear MDC for every call
+        MDC.clear();
+        try {
+            handleRoutingInformation(request);
+        } catch (Exception e) {
+            LOG.error("Handle routing information failed - so continue without new MDC settings", e);
+        }
+        return super.preHandle(request, response, handler);
+    }
+
+    void handleRoutingInformation(HttpServletRequest request) {
+        String reqURI = request.getRequestURI();
+        if (reqURI == null) {
+            return;
+        }
+        if (handledProjectAPICall(reqURI)) {
+            return;
+        }
+
+    }
+
+    private boolean handledProjectAPICall(String reqURI) {
+        int indexOf = reqURI.indexOf(APIConstants.API_PROJECT);
+        if (indexOf == -1) {
+            return false;
+        }
+        String part = reqURI.substring(indexOf + APIConstants.API_PROJECT.length());
+        String projectId = part;
+        int index = projectId.indexOf('/');
+        if (index != -1) {
+            projectId = part.substring(0, index);
+        }
+        MDC.put(LogConstants.MDC_SECHUB_PROJECT_ID, projectId);
+        if (index == -1) {
+            return true;
+        }
+        handleJobParameter(part);
+        return true;
+    }
+
+    private void handleJobParameter(String part) {
+        String[] splitted = part.split("/");
+        if (splitted == null || splitted.length == 0) {
+            return;
+        }
+        String uuid = null;
+        boolean useNext = false;
+        for (String split : splitted) {
+            if (useNext) {
+                uuid = split;
+                break;
+            }
+            if ("job".equals(split) || "false-positive".equals(split)) {
+                useNext = true;
+            }
+        }
+        if (uuid == null) {
+            return;
+        }
+        try {
+            UUID jobUUID = UUID.fromString(uuid);
+            MDC.put(LogConstants.MDC_SECHUB_JOB_UUID, jobUUID.toString());
+
+        } catch (IllegalArgumentException e) {
+            LOG.warn("Expected a UUID inside url but was no sechub job UUID");
+        }
+        return;
+    }
+
+}

--- a/sechub-server/src/main/java/com/daimler/sechub/server/SecHubWebMvcConfigurer.java
+++ b/sechub-server/src/main/java/com/daimler/sechub/server/SecHubWebMvcConfigurer.java
@@ -1,0 +1,15 @@
+package com.daimler.sechub.server;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class SecHubWebMvcConfigurer implements WebMvcConfigurer{  
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+       registry.addInterceptor(new SecHubServerMDCAsyncHandlerInterceptor());
+    }
+
+}

--- a/sechub-server/src/test/java/com/daimler/sechub/server/SecHubServerMDCAsyncHandlerInterceptorTest.java
+++ b/sechub-server/src/test/java/com/daimler/sechub/server/SecHubServerMDCAsyncHandlerInterceptorTest.java
@@ -1,0 +1,147 @@
+package com.daimler.sechub.server;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.UUID;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.MDC;
+
+import com.daimler.sechub.sharedkernel.LogConstants;
+import com.daimler.sechub.test.TestURLBuilder;
+
+public class SecHubServerMDCAsyncHandlerInterceptorTest {
+
+    private static final String DELETE_ME_ON_CLEAR = "delete-this-key";
+    private SecHubServerMDCAsyncHandlerInterceptor interceptorToTest;
+    private Object handler;
+    private HttpServletResponse response;
+    private HttpServletRequest request;
+
+    @Before
+    public void before() throws Exception {
+        MDC.put(DELETE_ME_ON_CLEAR, "should be cleared");
+        interceptorToTest = new SecHubServerMDCAsyncHandlerInterceptor();
+
+        response = mock(HttpServletResponse.class);
+        request = mock(HttpServletRequest.class);
+    }
+
+    @Test
+    public void mdc_is_cleared() throws Exception {
+        /* execute */
+        interceptorToTest.preHandle(request, response, handler);
+        
+        /* test */
+        assertNull(MDC.get(DELETE_ME_ON_CLEAR));
+    }
+
+    @Test
+    public void when_url_is_null_MDC_contains_not_jobuuid() throws Exception {
+        /* execute */
+        interceptorToTest.preHandle(request, response, handler);
+        
+        /* test */
+        assertNull(MDC.get(LogConstants.MDC_SECHUB_JOB_UUID));
+    }
+    
+    @Test
+    public void when_url_is_localhost_MDC_contains_not_jobuuid_no_projectid() throws Exception {
+        /* prepare */
+        when(request.getRequestURI()).thenReturn("https://localhost");
+        
+        /* execute */
+        interceptorToTest.preHandle(request, response, handler);
+        
+        /* test */
+        assertNull(MDC.get(LogConstants.MDC_SECHUB_JOB_UUID));
+        assertNull(MDC.get(LogConstants.MDC_SECHUB_PROJECT_ID));
+    }
+    
+    @Test
+    public void when_url_is_localhost_project_MDC_contains_not_jobuuid_no_projectid() throws Exception {
+        /* prepare */
+        when(request.getRequestURI()).thenReturn("https://localhost/api/project");
+        
+        /* execute */
+        interceptorToTest.preHandle(request, response, handler);
+        
+        /* test */
+        assertNull(MDC.get(LogConstants.MDC_SECHUB_JOB_UUID));
+    }
+    
+    @Test
+    public void when_url_is_localhost_project_myprojectId_MDC_contains_not_jobuuid_but_projectid() throws Exception {
+        /* prepare */
+        when(request.getRequestURI()).thenReturn("https://localhost/api/project/myprojectId");
+        
+        /* execute */
+        interceptorToTest.preHandle(request, response, handler);
+        
+        /* test */
+        assertNull(MDC.get(LogConstants.MDC_SECHUB_JOB_UUID));
+        assertEquals("myprojectId", MDC.get(LogConstants.MDC_SECHUB_PROJECT_ID));
+    }
+    
+    @Test
+    public void when_url_is_localhost_project_projectId_job_notUUID_contains_not_jobuuid_but_projectid() throws Exception {
+        /* prepare */
+        when(request.getRequestURI()).thenReturn("https://localhost/api/project/myprojectId/job/jobUUID");
+        
+        /* execute */
+        interceptorToTest.preHandle(request, response, handler);
+        
+        /* test */
+        assertNull(MDC.get(LogConstants.MDC_SECHUB_JOB_UUID));
+        assertEquals("myprojectId", MDC.get(LogConstants.MDC_SECHUB_PROJECT_ID));
+    }
+    
+    @Test
+    public void when_url_is_localhost_project_projectId_job_real_UUID_contains_jobuuid_and_projectid() throws Exception {
+        /* prepare */
+        UUID uuid = UUID.randomUUID();
+        when(request.getRequestURI()).thenReturn("https://localhost/api/project/myprojectId/job/"+uuid.toString());
+        
+        /* execute */
+        interceptorToTest.preHandle(request, response, handler);
+        
+        /* test */
+        assertEquals(uuid.toString(), MDC.get(LogConstants.MDC_SECHUB_JOB_UUID));
+        assertEquals("myprojectId", MDC.get(LogConstants.MDC_SECHUB_PROJECT_ID));
+    }
+    
+    @Test
+    public void when_url_is_user_removes_false_positives_from_project_job_uuid_is_set_and_projectId_as_well() throws Exception {
+        /* prepare */
+        UUID uuid = UUID.randomUUID();
+        when(request.getRequestURI()).thenReturn(TestURLBuilder.https(8443).buildUserRemovesFalsePositiveEntryFromProject("myprojectId", uuid.toString(), "findingid1"));
+        
+        /* execute */
+        interceptorToTest.preHandle(request, response, handler);
+        
+        /* test */
+        assertEquals(uuid.toString(), MDC.get(LogConstants.MDC_SECHUB_JOB_UUID));
+        assertEquals("myprojectId", MDC.get(LogConstants.MDC_SECHUB_PROJECT_ID));
+    }
+    
+    
+    @Test
+    public void when_url_is_user_buildApproveJobUrluuid_is_set_and_projectId_as_well() throws Exception {
+        /* prepare */
+        UUID uuid = UUID.randomUUID();
+        when(request.getRequestURI()).thenReturn(TestURLBuilder.https(8443).buildApproveJobUrl("myprojectId", uuid.toString()));
+        
+        /* execute */
+        interceptorToTest.preHandle(request, response, handler);
+        
+        /* test */
+        assertEquals(uuid.toString(), MDC.get(LogConstants.MDC_SECHUB_JOB_UUID));
+        assertEquals("myprojectId", MDC.get(LogConstants.MDC_SECHUB_PROJECT_ID));
+    }
+
+}

--- a/sechub-shared-kernel/src/main/java/com/daimler/sechub/sharedkernel/LogConstants.java
+++ b/sechub-shared-kernel/src/main/java/com/daimler/sechub/sharedkernel/LogConstants.java
@@ -1,9 +1,21 @@
 // SPDX-License-Identifier: MIT
 package com.daimler.sechub.sharedkernel;
 
+/**
+ * Log constants to use. Attention: MDC variants must be used wise! If you do not cleanup
+ * MDC or set always to correct values next logs can contain old MDC data. MDC is thread local
+ * so when threads are reused...
+ * @author Albert Tregnaghi
+ *
+ */
 public class LogConstants {
 
 	public static final String MDC_SECHUB_JOB_UUID="sechub_job_uuid";
+	
 	public static final String MDC_SECHUB_PROJECT_ID="sechub_project_id";
+	
+	/**
+	 * Log constant for MDC audit logs, reserved for audit log service only
+	 */
 	public static final String MDC_SECHUB_AUDIT_USERID="sechub_audit_userid";
 }


### PR DESCRIPTION
- rest calls do now automatically clear MDC of their thread
- rest calls try to estimate project and job uuid by request URI
  and set automatically into MDC
- parts having additonal threads do set and reset by their own

---
<sup>Albert Tregnaghi <albert.tregnaghi@daimler.com>, Daimler TSS GmbH, [imprint](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md)</sup>