### PR TITLE
improvements linterGo gradle task #313

### DIFF
--- a/sechub-cli/build.gradle
+++ b/sechub-cli/build.gradle
@@ -65,13 +65,11 @@ task linterGo(type:Exec) {
   description 'Executes go linter at sechub client sources and outputs warnings etc.'
   environment GOPATH: "${projectDir}"
 
-  workingDir "${projectDir}/src/daimler.com/sechub/cli"
-
   //on windows:
     if (OSUtil.isWindows()){
-        commandLine 'cmd', '/c', 'golint', 'daimler.com/sechub/cli', 'daimler.com/sechub/util'
+        commandLine 'cmd', '/c', 'golint', 'daimler.com/sechub/cli', 'daimler.com/sechub/util', 'daimler.com/sechub/testutil'
     }else{
-        commandLine 'golint', 'daimler.com/sechub/cli', 'daimler.com/sechub/util'
+        commandLine 'golint', 'daimler.com/sechub/cli', 'daimler.com/sechub/util', 'daimler.com/sechub/testutil'
     }
 
 }

--- a/sechub-cli/src/daimler.com/sechub/testutil/fileTestHelpers.go
+++ b/sechub-cli/src/daimler.com/sechub/testutil/fileTestHelpers.go
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: MIT
+
 package util
 
 import (


### PR DESCRIPTION
- workingDir variable is unused in linterGo (removed from task)
- added testutil package (although only for testing, we should have clean code there, also)
- fix of lint complaint in fileTestHelpers.go

closes #313 