### PR TITLE
#378: changed /check/alive endpoint from HTTP HEAD only to HTTP GET

### DIFF
--- a/sechub-doc/src/test/java/com/daimler/sechub/restdoc/AnonymousCheckAliveRestDocTest.java
+++ b/sechub-doc/src/test/java/com/daimler/sechub/restdoc/AnonymousCheckAliveRestDocTest.java
@@ -42,8 +42,8 @@ public class AnonymousCheckAliveRestDocTest {
 	private MockMvc mockMvc;
 
 	@Test
-	@UseCaseRestDoc(useCase=UseCaseAnonymousCheckAlive.class)
-	public void calling_check_alive_returns_HTTP_200() throws Exception {
+	@UseCaseRestDoc(useCase=UseCaseAnonymousCheckAlive.class, variant = "HEAD")
+	public void calling_check_alive_head_returns_HTTP_200() throws Exception {
 
 		/* execute */
 		/* @formatter:off */
@@ -51,7 +51,22 @@ public class AnonymousCheckAliveRestDocTest {
         			head(https(PORT_USED).buildCheckIsAliveUrl())
         		).
         andExpect(status().isOk()).
-        andDo(document(RestDocPathFactory.createPath(UseCaseAnonymousCheckAlive.class)));
+        andDo(document(RestDocPathFactory.createPath(UseCaseAnonymousCheckAlive.class, "HEAD")));
+
+        /* @formatter:on */
+	}
+	
+	@Test
+	@UseCaseRestDoc(useCase=UseCaseAnonymousCheckAlive.class, variant = "GET")
+	public void calling_check_alive_get_returns_HTTP_200() throws Exception {
+
+		/* execute */
+		/* @formatter:off */
+        this.mockMvc.perform(
+        			get(https(PORT_USED).buildCheckIsAliveUrl())
+        		).
+        andExpect(status().isOk()).
+        andDo(document(RestDocPathFactory.createPath(UseCaseAnonymousCheckAlive.class, "GET")));
 
         /* @formatter:on */
 	}

--- a/sechub-server-core/src/main/java/com/daimler/sechub/server/core/AnonymousCheckAliveRestController.java
+++ b/sechub-server-core/src/main/java/com/daimler/sechub/server/core/AnonymousCheckAliveRestController.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 package com.daimler.sechub.server.core;
 
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,9 +20,10 @@ public class AnonymousCheckAliveRestController {
 				name="REST API call",
 				needsRestDoc=true,
 				description="An anonymous user checks if the server is alive and running using the REST API"))
-	@RequestMapping(path = APIConstants.API_ANONYMOUS + "check/alive", method = RequestMethod.HEAD)
-	public void checkAlive() {
-	    /* do nothing here - its just a HEAD request */
+	@RequestMapping(path = APIConstants.API_ANONYMOUS + "check/alive", method = RequestMethod.GET, produces = {MediaType.APPLICATION_JSON_VALUE})
+	public String checkAlive() {
+		/* empty result, only HTTP STATUS 200 OK is of interest */
+	    return "";
 	}
 	/* @formatter:on */
 }

--- a/sechub-server-core/src/main/java/com/daimler/sechub/server/core/AnonymousCheckAliveRestController.java
+++ b/sechub-server-core/src/main/java/com/daimler/sechub/server/core/AnonymousCheckAliveRestController.java
@@ -20,7 +20,7 @@ public class AnonymousCheckAliveRestController {
 				name="REST API call",
 				needsRestDoc=true,
 				description="An anonymous user checks if the server is alive and running using the REST API"))
-	@RequestMapping(path = APIConstants.API_ANONYMOUS + "check/alive", method = RequestMethod.GET, produces = {MediaType.APPLICATION_JSON_VALUE})
+	@RequestMapping(path = APIConstants.API_ANONYMOUS + "check/alive", method = {RequestMethod.GET, RequestMethod.HEAD}, produces = {MediaType.APPLICATION_JSON_VALUE})
 	public String checkAlive() {
 		/* empty result, only HTTP STATUS 200 OK is of interest */
 	    return "";


### PR DESCRIPTION
Changes check/alive from HTTP HEAD to GET method for Kubernetes LivenessProbe

--- 
<sup>Albert Weißert <albert.weissert@daimler.com>, Daimler TSS GmbH, [imprint](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md)</sup>