### PR TITLE
Added documentation + made usecase numbers defined in code , closes #406

### DIFF
--- a/sechub-doc/src/docs/asciidoc/diagrams/diagram_overview_execution_profiles_and_config.puml
+++ b/sechub-doc/src/docs/asciidoc/diagrams/diagram_overview_execution_profiles_and_config.puml
@@ -1,0 +1,75 @@
+' SPDX-License-Identifier: MIT
+@startuml 
+
+' hide the class parts not wanted for the 
+hide circle
+hide methods
+hide fields
+
+package "Domain schedule" as domainScheduler {
+
+    entity "SecHub batch job" as scheduler {
+    }
+    
+}
+
+package "Domain product" as domainProduct{
+    entity "Product XYZ" as product {
+    
+    }
+    entity "Product adapter" as adapter {
+    }
+}
+
+package "Domain scan" as domainScan {
+
+    entity "Product execution store service" as execService{
+    }
+
+    entity "Product execution profile" as profile {
+    
+        * String **profileId**
+        String Description
+        Set<String> projectIds
+        Set<UUID> configurations
+    
+    }
+
+    entity "Product executor config " as config {
+        * UUID **uuid**
+        String name
+    }
+    
+    
+    entity "Scan service" as scanService {
+        
+    }
+    
+    entity "Product executor" as executor {
+        ProductIdentifier identifier
+        int version
+    }
+    
+}
+
+package "Domain administration" as domainAdministration{
+
+    entity "SecHub project" as project {
+    
+        * String **projectId**
+    
+    }
+}
+
+
+
+profile "1" --> "n" config : Profiles can\n reuse same config
+profile "1" ..> "n" project : Not direct related to project, only project id is known
+execService --> profile : knows
+execService --> executor : uses executor only \nwhen configured in profile\nand profile matches \nfor project to scan
+executor --> adapter: uses
+adapter --> product : calls
+scheduler .> scanService
+scanService -> execService
+'scheduler  ..> project
+@enduml 

--- a/sechub-doc/src/docs/asciidoc/documents/architecture/08_concepts.adoc
+++ b/sechub-doc/src/docs/asciidoc/documents/architecture/08_concepts.adoc
@@ -15,11 +15,14 @@ include::../shared/concepts/concept_simple_resilience.adoc[]
 === Mappings
 include::../shared/concepts/concept_mappings.adoc[]
 
-// Product delegation server (headline in include)
+// Product delegation server (headline in include - level3)
 include::../shared/concepts/concept_pds.adoc[]
 
-=== False-positive handling
+// False-positive handling (headline in include - level3)
 include::../shared/concepts/false-positive-handling/false-positive-handling.adoc[]
+
+// Product execution profiles and executor configurations (headline in include - level3)
+include::../shared/concepts/execution-profiles/concept_execution_profiles_and_config.adoc[]
 
 
 

--- a/sechub-doc/src/docs/asciidoc/documents/operations/01_sechub_server.adoc
+++ b/sechub-doc/src/docs/asciidoc/documents/operations/01_sechub_server.adoc
@@ -7,3 +7,5 @@ include::../shared/configuration/mapping.adoc[]
 
 include::../shared/configuration/scan_config.adoc[]
 
+include::../shared/configuration/initial_profile_and_executor_config.adoc[]
+

--- a/sechub-doc/src/docs/asciidoc/documents/operations/02_security_products.adoc
+++ b/sechub-doc/src/docs/asciidoc/documents/operations/02_security_products.adoc
@@ -4,6 +4,10 @@
 :checkmarx: Checkmarx
 == Security Products
 
+TIP: You must only setup those products you have listed inside your
+     profiles. See <<section-initial-profile-and-executors,execution profiles and executor configurations>> 
+  
+
 === {checkmarx}
 
 ==== What does the adapter do?

--- a/sechub-doc/src/docs/asciidoc/documents/shared/concepts/execution-profiles/concept_execution_profiles_and_config.adoc
+++ b/sechub-doc/src/docs/asciidoc/documents/shared/concepts/execution-profiles/concept_execution_profiles_and_config.adoc
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+=== Product execution profiles and executor configuration
+// see https://github.com/Daimler/sechub/issues/148 for issue details about executor config
+// see https://github.com/Daimler/sechub/issues/391 for issue details about execution profiles
+
+To have the possibility of using dedicated security products for different projects, to 
+disable/enable products on demand without server restart or just to test new products in one evaluation project but
+not for all other projects a runtime configuration is necessary.
+
+This is provided by execution profiles and and executor configurations.   
+
+==== Overview
+plantuml::diagrams/diagram_overview_execution_profiles_and_config.puml[format=svg, title="Overview profiles and configurations"]  
+
+==== Executor configuration
+An executor configuration represents a runtime configuration for product executors. The configuration
+has an enabled state. So it is possible to enable/disable product execution.
+
+==== Execution profile
+An execution profile can contain multiple executor configurations. The configurations can be shared 
+between multiple profiles. E.g. a config with name "pds-gosec-1" can be used in profiles "profileA"
+and also "profileB" at the same time. 
+
+Additionally a profile can be assigned to a project _(but technically we assign a projectId to a profile, because
+in domain `scan` we only know projectIds but no the `Project` entity...)_.
+
+The profile has also an enabled state - like executors. 
+
+==== How execution process uses profiles and configurations 
+`ScanService` is called by {sechub} batch operation from scheduler and contains the project id for the
+project to scan for. 
+
+When it comes to execution, `ProductExectionStoreService` fetches all enabled profiles related to the given
+project id and executes all enabled product executors for the wanted scan job - e.g. code scan product executors
+
+===== Results handling done by configured report executor or fallback
+All of the results returned by the dedicated product executors are stored in database. After this has been done,
+the configured report product executor(s) is (are) executed _(if none has been defined in at least one profile, the
+fallback will automatically use `Sereco` product executor version 1, which is embedded)_ 

--- a/sechub-doc/src/docs/asciidoc/documents/shared/concepts/false-positive-handling/false-positive-handling.adoc
+++ b/sechub-doc/src/docs/asciidoc/documents/shared/concepts/false-positive-handling/false-positive-handling.adoc
@@ -5,10 +5,11 @@
 
 
 [[concept-false-positive-handling]]
+=== False-positive handling
 
 {sechub} must be able to handle false positives of used products.
 
-=== General
+==== General
 
 Normally every commercial security product is able to mark false positives, but maybe not every tool
 has got a REST API for this issue, or some command line tools do not have an API for this. 
@@ -101,6 +102,13 @@ and
 
 `NOSECHUB-END`
 
+[WARNING]
+====
+`CLI analyzer` is already implemented which contains logic for search etc, but currently
+{sechub} does not use it because there is a need for PDS execution. We also need a 
+special type of executions introduced: `AnalyzerProductExecutor`, which is not at this moment.
+====
+ 
 [NOTE]
 ====
 In future we could provide additional identifiers for `NOSECHUB` to define which kind of
@@ -110,7 +118,6 @@ E.g. something like `NOSECHUB:PATH_TRAVERSAL,PWD_UNSECURE` etc. But if we implem
 SecHub Sereco must map product names of vulnerability to common identifiers!
 
 ====
-
 
 ===== Java
 
@@ -237,7 +244,7 @@ We need
 ** batch job must call the CLi tool with parameters +
    Those parameters must be defined in adapter call
 
-=== Sereco
+==== Sereco
 We need to enhance Sereco to understand analyzer data and filter
 
 [NOTE]

--- a/sechub-doc/src/docs/asciidoc/documents/shared/configuration/initial_profile_and_executor_config.adoc
+++ b/sechub-doc/src/docs/asciidoc/documents/shared/configuration/initial_profile_and_executor_config.adoc
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+[[section-initial-profile-and-executors]]
+=== Profile and executor configuration
+
+==== Executor configuration
+With an executor configuration a product executor can be configured for product execution.
+An executor will only be executed when configuration has been enabled!
+
+ifdef::usecasedoc[]
+Following usecases are supported:
+
+- <<section-usecase-UC_047,UC_047-Admin creates an executor configuration>>
+
+- <<section-usecase-UC_048,UC_048-Admin deletes executor configuration>>
+
+- <<section-usecase-UC_049,UC_049-Admin fetches executor configuration list>>
+
+- <<section-usecase-UC_050,UC_050-Admin fetches executor configuration>>
+
+- <<section-usecase-UC_051,UC_051-Admin updates executor configuration>>
+endif::usecasedoc[]
+
+==== Execution profile
+An execution profile can contain multiple executor configurations. The configurations can be 
+shared between multiple profiles. 
+
+[NOTE]
+====
+As an example: a config with name "pds-gosec-1" can be used in profiles "profileA"
+and also "profileB" at the same time. 
+====
+
+Additionally a profile can be assigned to a project.
+
+ifdef::techdoc[]
+TIP: Technically we assign a projectId to a profile, because in domain `scan` we only know projectIds but not `Project` entity...
+endif::techdoc[]
+ 
+The profile has also an enabled state - like executors.
+
+[IMPORTANT]
+====
+To have a scan job running for a project we need
+- at least one enabled profile assigned to project
+- also at least one configuration inside the profile must be enabled and suitable for wanted scan type (e.g. codescan) 
+==== 
+
+ifdef::usecasedoc[]
+Following usecases are supported:
+
+- <<section-usecase-UC_052,UC_052-Admin creates an execution proflie>>
+
+- <<section-usecase-UC_053,UC_053-Admin deletes execution profile>>
+
+- <<section-usecase-UC_054,UC_054-Admin updates execution profile>>
+
+- <<section-usecase-UC_055,UC_055-Admin fetches execution profile>>
+
+- <<section-usecase-UC_056,UC_056-Admin fetches execution proflie list>>
+
+- <<section-usecase-UC_057,UC_057-Admin assigns execution profile to project>>
+
+- <<section-usecase-UC_058,UC_058-Admin unassigns execution profile from project>>
+endif::usecasedoc[]

--- a/sechub-doc/src/docs/asciidoc/documents/shared/configuration/mapping.adoc
+++ b/sechub-doc/src/docs/asciidoc/documents/shared/configuration/mapping.adoc
@@ -5,7 +5,7 @@ Mapping is used for simple key value configuration, but also for more sophistica
 behaviour like done in <<scan-config-about,scan configuration>>.
 
 ==== REST API
-Configuration is always done by REST API.
+Configuration can be done by REST API.
 
 - <<section-ucrestdoc-uc-UC_037,REST API for UC_037-Admin updates mapping configuration >>
 - <<section-ucrestdoc-uc-UC_038,REST API for UC_038-Admin fetches mapping configuration >>

--- a/sechub-doc/src/docs/asciidoc/sechub-operations.adoc
+++ b/sechub-doc/src/docs/asciidoc/sechub-operations.adoc
@@ -32,7 +32,7 @@ include::documents/operations/01_sechub_server.adoc[]
 include::documents/operations/02_security_products.adoc[]
 
 <<<<
-// 3. Coding conventions
+// 3. Onboarding
 include::documents/operations/03_onboarding.adoc[]
 
 

--- a/sechub-doc/src/main/java/com/daimler/sechub/docgen/usecase/UseCaseAsciiDocGenerator.java
+++ b/sechub-doc/src/main/java/com/daimler/sechub/docgen/usecase/UseCaseAsciiDocGenerator.java
@@ -49,6 +49,9 @@ public class UseCaseAsciiDocGenerator {
         Context context = new Context();
         context.diagramsGenFolder = diagramsGenFolder;
         int h = 3;
+        context.addLine("");
+        context.addLine(":usecasedoc:");
+        context.addLine("");
         context.addLine("[[section-usecases]]");
         context.addLine(headline(h++) + "Use cases");
         context.addLine("");

--- a/sechub-shared-kernel/src/main/java/com/daimler/sechub/sharedkernel/usecases/UseCaseIdentifier.java
+++ b/sechub-shared-kernel/src/main/java/com/daimler/sechub/sharedkernel/usecases/UseCaseIdentifier.java
@@ -4,152 +4,135 @@ package com.daimler.sechub.sharedkernel.usecases;
 /**
  * Identifier enumeration for use cases. <br>
  * <br>
- * <b>The ordering of the enums is the ordering used for uniqueId
- * calculation!</b> Calculated ID will be used in documentation to order
- * content. It also is important when comparing different versions of a
- * documentation.<br>
- * For an example:<br>
- * When adding new use cases the <br>
- * So <b>do not change the ordering light hearted!</b> The main purpose why
- * using enums here is to prevent manual managing unique identifiers via string
- * constants. The enum will have always unique ids which can be used for
- * documentation.
- *
+ * The ordering of the enums does not matter because the usecase number is given 
+ * at construction time and used for unique id generation.<br><br>But DO NOT change the numbers
+ * because they are used inside asciidoc documentation files for references and would not be 
+ * valid any longer when there are changes made.
+ * 
  * @author Albert Tregnaghi
  *
  */
 public enum UseCaseIdentifier {
 
-    /*
-     * The ordering of the enums is the ordering used for uniqueId calculation! So
-     * do not change the ordering lighthearded!
-     */
+    UC_SIGNUP(1),
 
-    UC_SIGNUP,
+    UC_ADMIN_LISTS_OPEN_USER_SIGNUPS(2),
 
-    UC_ADMIN_LISTS_OPEN_USER_SIGNUPS,
+    UC_ADMIN_ACCEPTS_SIGNUP(3),
 
-    UC_ADMIN_ACCEPTS_SIGNUP,
+    UC_ADMIN_LISTS_ALL_ACCEPTED_USERS(4),
 
-    UC_ADMIN_LISTS_ALL_ACCEPTED_USERS,
+    UC_USER_CREATES_JOB(5),
 
-    UC_USER_CREATES_JOB,
+    UC_USER_UPLOADS_SOURCECODE(6),
 
-    UC_USER_UPLOADS_SOURCECODE,
+    UC_USER_APPROVES_JOB(7),
 
-    UC_USER_APPROVES_JOB,
+    UC_SCHEDULER_STARTS_JOB(8),
 
-    UC_SCHEDULER_STARTS_JOB,
+    UC_USER_GET_JOB_STATUS(9),
 
-    UC_USER_GET_JOB_STATUS,
+    UC_USER_GET_JOB_REPORT(10),
 
-    UC_USER_GET_JOB_REPORT,
+    UC_USER_USES_CLIENT_TO_SCAN(11),
 
-    UC_USER_USES_CLIENT_TO_SCAN,
+    UC_USER_CLICKS_LINK_TO_GET_NEW_API_TOKEN(12),
 
-    UC_USER_CLICKS_LINK_TO_GET_NEW_API_TOKEN,
+    UC_ADMIN_CREATES_PROJECT(13),
 
-    UC_ADMIN_CREATES_PROJECT,
+    UC_ADMIN_LISTS_ALL_PROJECTS(14),
 
-    UC_ADMIN_LISTS_ALL_PROJECTS,
+    UC_ADMIN_ASSIGNS_USER_TO_PROJECT(15),
 
-    UC_ADMIN_ASSIGNS_USER_TO_PROJECT,
+    UC_ADMIN_UNASSIGNS_USER_FROM_PROJECT(16),
 
-    UC_ADMIN_UNASSIGNS_USER_FROM_PROJECT,
+    UC_ADMIN_SHOWS_USER_DETAILS(17),
 
-    UC_ADMIN_SHOWS_USER_DETAILS,
+    UC_ADMIN_DELETES_USER(18),
 
-    UC_ADMIN_DELETES_USER,
+    UC_ADMIN_DELETES_SIGNUP(19),
 
-    UC_ADMIN_DELETES_SIGNUP,
+    UC_ADMIN_DELETES_PROJECT(20),
 
-    UC_ADMIN_DELETES_PROJECT,
+    UC_ADMIN_SHOWS_PROJECT_DETAILS(21),
 
-    UC_ADMIN_SHOWS_PROJECT_DETAILS,
+    UC_UPDATE_PROJECT_WHITELIST(22),
 
-    UC_UPDATE_PROJECT_WHITELIST,
+    UC_ADMIN_LISTS_ALL_RUNNING_JOBS(23),
 
-    UC_ADMIN_LISTS_ALL_RUNNING_JOBS,
+    UC_USER_REQUESTS_NEW_APITOKEN(24),
 
-    UC_USER_REQUESTS_NEW_APITOKEN,
+    UC_USER_SHOWS_PROJECT_SCAN_INFO(25),
 
-    UC_USER_SHOWS_PROJECT_SCAN_INFO,
+    UC_ADMIN_DOWNLOADS_FULL_DETAILS_ABOUT_SCAN_JOB(26),
 
-    UC_ADMIN_DOWNLOADS_FULL_DETAILS_ABOUT_SCAN_JOB,
+    UC_ADMIN_GRANTS_ADMIN_RIGHT_TO_ANOTHER_USER(27),
 
-    UC_ADMIN_GRANTS_ADMIN_RIGHT_TO_ANOTHER_USER,
+    UC_ADMIN_REVOKES_ADMIN_RIGHTS_FROM_ANOTHER_ADMIN(28),
 
-    UC_ADMIN_REVOKES_ADMIN_RIGHTS_FROM_ANOTHER_ADMIN,
+    UC_ADMIN_LISTS_ALL_ADMINS(29),
 
-    UC_ADMIN_LISTS_ALL_ADMINS,
+    UC_ADMIN_DISABLES_SCHEDULER_JOB_PROCESSING(30),
 
-    UC_ADMIN_DISABLES_SCHEDULER_JOB_PROCESSING,
+    UC_ADMIN_ENABLES_SCHEDULER_JOB_PROCESSING(31),
 
-    UC_ADMIN_ENABLES_SCHEDULER_JOB_PROCESSING,
+    UC_ADMIN_TRIGGERS_REFRESH_SCHEDULER_STATUS(32),
 
-    UC_ADMIN_TRIGGERS_REFRESH_SCHEDULER_STATUS,
+    UC_ADMIN_LIST_STATUS_INFORMATION(33),
 
-    UC_ADMIN_LIST_STATUS_INFORMATION,
+    UC_ADMIN_CANCELS_JOB(34),
 
-    UC_ADMIN_CANCELS_JOB,
+    UC_USER_DEFINES_PROJECT_MOCKDATA_CONFIGURATION(35),
 
-    UC_USER_DEFINES_PROJECT_MOCKDATA_CONFIGURATION,
+    UC_USER_RETRIEVES_PROJECT_MOCKDATA_CONFIGURATION(36),
 
-    UC_USER_RETRIEVES_PROJECT_MOCKDATA_CONFIGURATION,
+    UC_ADMIN_UPDATES_MAPPING_CONFIGURATION(37),
 
-    UC_ADMIN_UPDATES_MAPPING_CONFIGURATION,
+    UC_ADMIN_FETCHES_MAPPING_CONFIGURATION(38),
 
-    UC_ADMIN_FETCHES_MAPPING_CONFIGURATION,
-	
-	UC_ANONYMOUS_CHECK_ALIVE,
-	
-	UC_ADMIN_CHECKS_SERVER_VERSION,
-	
-	UC_ADMIN_RESTARTS_JOB,
-	
-	UC_ADMIN_RESTARTS_JOB_HARD,
-	
-	UC_ADMIN_RECEIVES_NOTIFICATOIN_ABOUT_CLUSTER_MEMBER_START,
-	
-	UC_USER_MARKS_FALSE_POSITIVES_FOR_FINISHED_JOB,
-	
-	UC_USER_UNMARKS_FALSE_POSITIVES,
-	
-	UC_USER_FETCHES_FALSE_POSITIVE_CONFIGURATION_OF_PROJECT,
-	
-	/* executors */
-	UC_ADMIN_CREATES_EXECUTOR_CONFIGURATION,
-	
-	UC_ADMIN_DELETES_EXECUTOR_CONFIGURATION,
-	
-	UC_ADMIN_FETCHES_EXECUTOR_CONFIGURATION_LIST,
-	
-	UC_ADMIN_FETCHES_EXECUTOR_CONFIGURATION,
-	
-	UC_ADMIN_UPDATES_EXECUTOR_CONFIGURATION,
-	
-	/* execution profiles */
-	UC_ADMIN_CREATES_EXECUTION_PROFILE,
-	
-	UC_ADMIN_DELETES_EXECUTION_PROFILE,
-	
-	UC_ADMIN_UPDATES_EXECUTION_PROFILE,
+    UC_ANONYMOUS_CHECK_ALIVE(39),
 
-	UC_ADMIN_FETCHES_EXECUTION_PROFILE,
-	
-	UC_ADMIN_FETCHES_EXECUTION_PROFILE_LIST,
+    UC_ADMIN_CHECKS_SERVER_VERSION(40),
 
-	// optional/convenience (later)
-//	UC_ADMIN_ADDS_CONFIG_TO_EXECUTION_PROFILE,
-//	
-//	UC_ADMIN_REMOVES_CONFIG_FROM_EXECUTION_PROFILE,
-	
-	UC_ADMIN_ASSIGNS_EXECUTION_PROFILE_TO_PROJECT,
-	
-	UC_ADMIN_UNASSIGNS_EXECUTION_PROFILE_FROM_PROJECT,
-	
-	
-	;
+    UC_ADMIN_RESTARTS_JOB(41),
+
+    UC_ADMIN_RESTARTS_JOB_HARD(42),
+
+    UC_ADMIN_RECEIVES_NOTIFICATOIN_ABOUT_CLUSTER_MEMBER_START(43),
+
+    UC_USER_MARKS_FALSE_POSITIVES_FOR_FINISHED_JOB(44),
+
+    UC_USER_UNMARKS_FALSE_POSITIVES(45),
+
+    UC_USER_FETCHES_FALSE_POSITIVE_CONFIGURATION_OF_PROJECT(46),
+
+    /* executors */
+    UC_ADMIN_CREATES_EXECUTOR_CONFIGURATION(47),
+
+    UC_ADMIN_DELETES_EXECUTOR_CONFIGURATION(48),
+
+    UC_ADMIN_FETCHES_EXECUTOR_CONFIGURATION_LIST(49),
+
+    UC_ADMIN_FETCHES_EXECUTOR_CONFIGURATION(50),
+
+    UC_ADMIN_UPDATES_EXECUTOR_CONFIGURATION(51),
+
+    /* execution profiles */
+    UC_ADMIN_CREATES_EXECUTION_PROFILE(52),
+
+    UC_ADMIN_DELETES_EXECUTION_PROFILE(53),
+
+    UC_ADMIN_UPDATES_EXECUTION_PROFILE(54),
+
+    UC_ADMIN_FETCHES_EXECUTION_PROFILE(55),
+
+    UC_ADMIN_FETCHES_EXECUTION_PROFILE_LIST(56),
+
+    UC_ADMIN_ASSIGNS_EXECUTION_PROFILE_TO_PROJECT(57),
+
+    UC_ADMIN_UNASSIGNS_EXECUTION_PROFILE_FROM_PROJECT(58),
+
+    ;
 
     /* +-----------------------------------------------------------------------+ */
     /* +............................ Helpers ................................+ */
@@ -162,17 +145,15 @@ public enum UseCaseIdentifier {
     }
 
     private static final int WANTED_ID_LENGTH = 3;
-    private static int counter;
-
-    private UseCaseIdentifier() {
-        this.uniqueId = createUseCaseID();
+    
+    private UseCaseIdentifier(int number) {
+        this.uniqueId = createUseCaseID(number);
     }
 
-    private static String createUseCaseID() {
-        counter++;
+    static String createUseCaseID(int usecaseNumber) {
         StringBuilder sb = new StringBuilder();
 
-        sb.append(counter);
+        sb.append(usecaseNumber);
         while (sb.length() < WANTED_ID_LENGTH) {
             sb.insert(0, "0");
         }

--- a/sechub-shared-kernel/src/test/java/com/daimler/sechub/sharedkernel/usecases/UseCaseIdentifierTest.java
+++ b/sechub-shared-kernel/src/test/java/com/daimler/sechub/sharedkernel/usecases/UseCaseIdentifierTest.java
@@ -1,0 +1,47 @@
+package com.daimler.sechub.sharedkernel.usecases;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+public class UseCaseIdentifierTest {
+
+    @Test
+    public void usecase_numbers_are_unique() {
+        for (UseCaseIdentifier identifier: UseCaseIdentifier.values()){
+            searchForDuplicates(identifier);
+        }
+    }
+
+    @Test
+    public void usecase_numbers_are_without_fragmentation() {
+        List<String> list = new ArrayList<>();
+        for (UseCaseIdentifier identifier: UseCaseIdentifier.values()){
+            list.add(identifier.uniqueId());
+        }
+        for (int i=0;i<list.size();i++) {
+            int nr = i+1;
+            String toSearch = UseCaseIdentifier.createUseCaseID(nr);
+            if (! list.contains(toSearch)){
+                fail("Expected usecase "+toSearch+" was not found! Seems to be there is a fragmentation!");
+            }
+                    
+        }
+    }
+    
+    private void searchForDuplicates(UseCaseIdentifier source) {
+        for (UseCaseIdentifier identifier: UseCaseIdentifier.values()){
+            if (source==identifier) {
+                continue;
+            }
+            /* not same so check id */
+            if (source.uniqueId().equalsIgnoreCase(identifier.uniqueId())) {
+                fail("Found duplicates:\n"+source.name()+" and\n"+identifier.name()+"\n  have both same identifier:"+identifier.uniqueId());
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
- added documentation for execution profiles and executor configuration
- changed UsecaseIdentifier enumeration: developers now MUST define
  id inside constructor. Reason: So it's clear which number is used
  inside documentation. Uniqueness and avoiding of fragmentation is
  solved by unit tests

---
<sup>Albert Tregnaghi <albert.tregnaghi@daimler.com>, Daimler TSS GmbH, [imprint](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md)</sup>