### PR TITLE
#543: word-break for long callstack strings with alternating backgrou…

### DIFF
--- a/sechub-scan/src/main/resources/templates/report/html/fragments.html
+++ b/sechub-scan/src/main/resources/templates/report/html/fragments.html
@@ -220,7 +220,7 @@
 	display: table-row;
 }
 
-rTableRowHead {
+.rTableRowHead {
 	display: table-row;
 }
 

--- a/sechub-scan/src/main/resources/templates/report/html/fragments.html
+++ b/sechub-scan/src/main/resources/templates/report/html/fragments.html
@@ -220,6 +220,18 @@
 	display: table-row;
 }
 
+rTableRowHead {
+	display: table-row;
+}
+
+.rTableRow:nth-child(even) {
+	background: #f0f0f0;
+}
+
+.rTableRow:nth-child(odd) {
+	background: #fefefe;
+}
+
 .rTableHeading {
 	display: table-header-group;
 }
@@ -234,6 +246,7 @@
 
 .rTableCell, .rTableHead {
 	display: table-cell;
+	word-break: break-all;
 }
 
 .rTableHead {
@@ -260,7 +273,7 @@ details:not([open]) summary::after {
 <td>
 	<div th:if="!${codeScanSupport.isCodeScan(finding)}" th:text="${finding.description}">Description1</div>
 	<div class="rTable" th:if="${codeScanSupport.isCodeScan(finding)}">
-		<div class="rTableRow">
+		<div class="rTableRowHead">
 			<div class="rTableHead" style="width:5%">Id</div>
 			<div class="rTableHead" style="width:25%">Location</div>
 			<div class="rTableHead" style="width:5%">Line</div>
@@ -281,7 +294,7 @@ details:not([open]) summary::after {
 	<details th:if="${codeScanSupport.isCodeScan(finding)}">
 		<summary data-open="Open Callstack" data-close="Close Callstack"></summary>
 		<div class="rTable">
-			<div class="rTableRow">
+			<div class="rTableRowHead">
 				<div class="rTableHead" style="width:5%">Id</div>
 				<div class="rTableHead" style="width:25%">Location</div>
 				<div class="rTableHead" style="width:5%">Line</div>

--- a/sechub-scan/src/main/resources/templates/report/html/scanresult.css
+++ b/sechub-scan/src/main/resources/templates/report/html/scanresult.css
@@ -219,7 +219,7 @@
 	display: table-row;
 }
 
-rTableRowHead {
+.rTableRowHead {
 	display: table-row;
 }
 

--- a/sechub-scan/src/main/resources/templates/report/html/scanresult.css
+++ b/sechub-scan/src/main/resources/templates/report/html/scanresult.css
@@ -219,6 +219,18 @@
 	display: table-row;
 }
 
+rTableRowHead {
+	display: table-row;
+}
+
+.rTableRow:nth-child(even) {
+	background: #f0f0f0;
+}
+
+.rTableRow:nth-child(odd) {
+	background: #fefefe;
+}
+
 .rTableHeading {
 	display: table-header-group;
 }
@@ -233,6 +245,7 @@
 
 .rTableCell, .rTableHead {
 	display: table-cell;
+	word-break: break-all;
 }
 
 .rTableHead {


### PR DESCRIPTION
closes #543 

adds line-break on very long location strings like this one:

![image](https://user-images.githubusercontent.com/71753812/106908067-395caa80-66ff-11eb-989c-fce4be16f80e.png)


---
<sup>Albert Weißert <albert.weissert@daimler.com>, Daimler TSS GmbH, [imprint](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md)</sup>
