### PR TITLE
Feature 642 upgrade beanutils

### DIFF
--- a/libraries.gradle
+++ b/libraries.gradle
@@ -72,7 +72,7 @@ ext {
          apache_httpcomponents_core:            "org.apache.httpcomponents:httpcore:4.4.9",
          // https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient
          apache_httpcomponents_client:          "org.apache.httpcomponents:httpclient:4.5.10",
-         apache_commons_validator:              "commons-validator:commons-validator:1.6",
+         apache_commons_validator:              "commons-validator:commons-validator:1.7",
          apache_commons_io:                     "commons-io:commons-io:2.6",
          apache_commons_cli:					"commons-cli:commons-cli:1.4",
          apache_commons_lang3:					"org.apache.commons:commons-lang3:3.12.0",


### PR DESCRIPTION
- upgrade commons-validator to v1.7
- commons-validator upgrades Apache commons beanutils to 1.9.4 -> fixes CVE-2019-10086

Closes: #642 