### PR TITLE
improve-quickstart-guide #305

### DIFF
--- a/build
+++ b/build
@@ -1,0 +1,10 @@
+#!/bin/bash 
+cd `dirname $0`
+
+# This script builds SecHub server and client
+# 
+
+echo "********************************************************************"
+echo "* Build software " 
+echo "********************************************************************"
+./gradlew ensureLocalhostCertificate build buildGo -x :sechub-integrationtest:test

--- a/buildDoc
+++ b/buildDoc
@@ -1,4 +1,5 @@
 #!/bin/bash 
+cd `dirname $0`
 
 # This script build full documentation and also creates all precondition parts
 # So users can checkout from github and call this.
@@ -7,16 +8,15 @@
 # repository root folder. 
 # 
 
-echo "********************************************************************"
-echo "* Build software artifacts - necessary as precondition" 
-echo "********************************************************************"
-./gradlew ensureLocalhostCertificate build buildGo -x :sechub-integrationtest:test
- 
+./build
+
+echo 
 echo "********************************************************************"
 echo "* Collect runtime information about some started artefacts" 
 echo "********************************************************************"
 ./gradlew integrationtest
 
+echo
 echo "********************************************************************"
 echo "* Build documents + pages by using static and former collected info" 
 echo "********************************************************************"

--- a/sechub-doc/src/docs/asciidoc/sechub-quickstart-guide.adoc
+++ b/sechub-doc/src/docs/asciidoc/sechub-quickstart-guide.adoc
@@ -29,7 +29,7 @@ The following topics are covered:
 
 === Requirements
 
-* Java 11 SDK
+* Java SDK (We are still compatible with Java 8 and will continue to do so. We aim to support all long term support versions (LTS) of the JDK: Java 8, 11 and 17 when released.)
 * Git
 * cURL
 * jq

--- a/sechub-doc/src/docs/asciidoc/sechub-quickstart-guide.adoc
+++ b/sechub-doc/src/docs/asciidoc/sechub-quickstart-guide.adoc
@@ -20,46 +20,42 @@ The following topics are covered:
 
 * [x] Getting SecHub
 * [x] Building SecHub
-* [x] Starting SecHub in Integration Test Server mode
-* [x] Getting default passwords
-* [x] Working with the REST API and https://curl.haxx.se/[cURL]
+* [x] Starting SecHub server in Integration Test mode
+* [x] Default passwords
+* [x] Working with the REST API
+* [x] Creating a project on SecHub server
+* [x] Code scan with the SecHub client
 * [x] Stopping the server
 
 === Requirements
 
-* Java SDK
+* Java 11 SDK
 * Git
 * cURL
+* jq
 
-==== Alpine Linux 3.10, 3.11 & 3.12:
-
-Java 8:
-----
-apk add openjdk8 curl git bash
-----
-
-Java 11:
+==== Alpine Linux:
 
 ----
-apk add openjdk11 curl git bash
+apk add openjdk11 curl git bash jq
 ----
 
-==== Debian 10:
+==== Debian:
 
 ----
-sudo apt install git openjdk-11-jdk curl
+sudo apt install git openjdk-11-jdk curl jq
 ----
 
-==== Fedora 32 & 33 and CentOS 8:
+==== Fedora and CentOS:
 
 ----
-sudo dnf install git java-1.8.0-openjdk-devel curl
+sudo dnf install git java-11-openjdk-devel curl jq
 ----
 
-==== Ubuntu 18.04 & 20.04:
+==== Ubuntu:
 
 ----
-sudo apt install git openjdk-8-jdk curl
+sudo apt install git openjdk-11-jdk curl jq
 ----
 
 === Instructions
@@ -67,77 +63,46 @@ sudo apt install git openjdk-8-jdk curl
 Let's start with:
 
 . Cloning the repository
-+
 ----
-$ cd ~
-$ git clone https://github.com/Daimler/sechub.git
-$ cd sechub
+cd ~
+git clone https://github.com/Daimler/sechub.git
+cd sechub
 ----
 
-. Generate a self-signed certificate
-+
-----
-~/develop/sechub$ ./gradlew ensureLocalhostCertificate
-----
-+
-.Proxy
 [TIP]
 --
+**Proxy**: +
 In case you have to connect via proxy to the internet, please have a look on how to setup a proxy in the Gradle documentation: https://docs.gradle.org/current/userguide/build_environment.html#sec:accessing_the_web_via_a_proxy[Accessing the web through a HTTP proxy]
 
-Example:
-
+Example: +
+Add these lines to your ~/.gradle/gradle.properties file:
 ----
-./gradlew -Dhttp.proxyHost=locahost -Dhttp.proxyPort=3128 -Dhttps.proxyHost=localhost -Dhttps.proxyPort=3128 ensureLocalhostCertificate
+systemProp.http.proxyHost=yourproxy.youcompany.com
+systemProp.http.proxyPort=3128
+systemProp.http.proxyUser=userid
+systemProp.http.proxyPassword=password
+systemProp.http.nonProxyHosts=*.nonproxyrepos.com|localhost
 ----
 --
 
+[start=2]
 . Build SecHub
-+
 ----
-~/develop/sechub$ ./gradlew build
+./build
 ----
 
-. Start integration test server
-+
+[start=3]
+. Start SecHub server in Integration Test mode
 ----
-~/develop/sechub$ ./gradlew startIntegrationTestServer
+./gradlew startIntegrationTestServer
 ----
-+
+
 WARNING: Do not use the Integration Test Server mode in production.
-+
-.Logs
-[NOTE]
-In case of an error message or failure, you can find the server log under: `./sechub-integrationtest/integrationtest-server.log`.
 
-. Test if the server is up and running
-+
-[source,bash]
-----
-$ curl --insecure --head https://localhost:8443/api/anonymous/check/alive
-----
-+
-NOTE: The `insecure` parameter is needed, because a self-signed certificate is used in this guide.
-+
-[source,bash]
-----
-HTTP/1.1 200 # <1>
-X-Content-Type-Options: nosniff
-X-XSS-Protection: 1; mode=block
-Cache-Control: no-cache, no-store, max-age=0, must-revalidate
-Pragma: no-cache
-Expires: 0
-Strict-Transport-Security: max-age=31536000 ; includeSubDomains
-X-Frame-Options: DENY
-Content-Length: 0
-Date: Thu, 12 Dec 2019 15:26:19 GMT
-----
-<1> You should get a `HTTP 200` code back from the running integration server.
+[start=4]
+. Credentials
 
-. Get the initial credentials
-+
 Open the log file `./sechub-integrationtest/integrationtest-server.log` and search for:
-+
 ----
 ##################### ATTENTION #####################################################
 # Created initial admin:'int-test_superadmin' with password:'{noop}int-test_superadmin-pwd'
@@ -146,33 +111,114 @@ Open the log file `./sechub-integrationtest/integrationtest-server.log` and sear
 # Everybody able to read this log file has access to these admin credentials!
 #####################################################################################
 ----
-+
-Superadmin username and password:
-+
-----
-username: int-test_superadmin
-password: int-test_superadmin-pwd
-----
-+
-User account username and password:
-+
-----
-username: int-test_onlyuser
-password: int-test_onlyuser-pwd
-----
-+
-IMPORTANT: The `{noop}` has to be excluded from the password string `{noop}int-test_superadmin-pwd`, therefor the password is: `int-test_superadmin-pwd`
 
-. List all users as administrator
+[NOTE]
+--
+In case of an error message or failure, you can find the SecHub server log under: `./sechub-integrationtest/integrationtest-server.log`.
+
+The `{noop}` has to be excluded from the password string, therefore the password is: `int-test_superadmin-pwd`
+--
+
+These are the initial credentials when starting SecHub server in integration-test mode:
+
+SecHub Superadmin:
+[quote]
+username: `int-test_superadmin`
+password: `int-test_superadmin-pwd`
+
+SecHub User account:
+[quote]
+username: `int-test_onlyuser`
+password: `int-test_onlyuser-pwd`
+
+[start=5]
+. Environment variables
 +
-List all users on the SecHub server using the administrator credentials
-+
+Set search path and some environemt variables to ease handling later on (SecHub client and `sechub-api.sh` script):
+[source,bash]
 ----
-curl --insecure --user int-test_superadmin:int-test_superadmin-pwd 'https://localhost:8443/api/admin/users'; echo
+export SECHUB_SERVER=https://localhost:8443
+export SECHUB_USERID=int-test_superadmin
+export SECHUB_APITOKEN=int-test_superadmin-pwd
+export SECHUB_TRUSTALL=true
+export PATH="`pwd`/sechub-cli/build/go/platform/linux-amd64:`pwd`/sechub-developertools/scripts:$PATH"
 ----
 
-. Stop server
+[start=6]
+. Test: List all users as administrator
+
+[NOTE]
+`sechub-api.sh` is a Bash helper script based on `curl` that eases the use of the https://daimler.github.io/sechub/latest/sechub-restapi.html[SecHub server's REST api]. We use it here to get a list of the users.
+
+[source,bash]
+----
+sechub-api.sh user_list
+----
+
+Expected result:
+[source,json]
+----
+[
+  "int-test_onlyuser",
+  "int-test_superadmin"
+]
+----
+
+[start=7]
+. Create a project on SecHub server
+
+The output of the api calls are omitted here for better readability:
+[source,bash]
+----
+# Create "testproject"
+sechub-api.sh project_create testproject int-test_superadmin
+
+# Assign "test_superadmin" as scan user to our project
+sechub-api.sh project_assign_user testproject int-test_superadmin
+
+# List project details
+sechub-api.sh project_details testproject
+----
+
+
+[start=8]
+. Scan with SecHub client
+
+Let's do a scan of our SecHub code:
+
+[source,bash]
+----
+sechub -project testproject -reportformat html scan
+
+WARNING: Configured to trust all - means unknown service certificate is accepted. Don't use this in production!
+ _____           _   _       _
+/  ___|         | | | |     | |
+\ `--.  ___  ___| |_| |_   _| |__
+ `--. \/ _ \/ __|  _  | | | | '_ \
+/\__/ /  __/ (__| | | | |_| | |_) |
+\____/ \___|\___\_| |_/\__,_|_.__/ Client Version 0.0.0-3e13084-dirty-20210622120507
+
+2021-06-22 13:26:24 (+02:00) Creating new sechub job
+2021-06-22 13:26:24 (+02:00) Zipping folder: . (/home/user/sechub)
+2021-06-22 13:26:25 (+02:00) Uploading source zip file
+2021-06-22 13:26:26 (+02:00) Approve sechub job
+2021-06-22 13:26:26 (+02:00) Waiting for job 7045e25f-592b-46bf-9713-c31995d37e99 to be done
+                             .
+2021-06-22 13:26:30 (+02:00) Fetching result (format=html) for job 7045e25f-592b-46bf-9713-c31995d37e99
+2021-06-22 13:26:30 (+02:00) SecHub report written to sechub_report_testproject_7045e25f-592b-46bf-9713-c31995d37e99.html
+  GREEN - no severe security vulnerabilities identified
+----
+_Congratulations! You have done your first SecHub code scan._ +
+You can open the SecHub report file in your browser.
+
+[NOTE]
+In order to scan, you need a `sechub.json` config file. In our case, it is already in the repository so we can use it right away. +
+ +
+For real results, you have to define an 'execution profile' with a scanner (via a product adapter) attached. Assign it to your project and you get real results. See https://daimler.github.io/sechub/latest/sechub-operations.html#section-initial-profile-and-executors[SecHub documentation] for details.
+
+[start=9]
+. Stop SecHub integration test server
 +
 ----
-~/develop/sechub$ ./gradlew stopIntegrationTestServer
+./gradlew stopIntegrationTestServer
 ----

--- a/sechub-doc/src/docs/asciidoc/sechub-quickstart-guide.adoc
+++ b/sechub-doc/src/docs/asciidoc/sechub-quickstart-guide.adoc
@@ -134,7 +134,7 @@ password: `int-test_onlyuser-pwd`
 [start=5]
 . Environment variables
 +
-Set search path and some environemt variables to ease handling later on (SecHub client and `sechub-api.sh` script):
+Set search path and some environment variables to ease handling later on (SecHub client and `sechub-api.sh` script):
 [source,bash]
 ----
 export SECHUB_SERVER=https://localhost:8443
@@ -173,7 +173,7 @@ The output of the api calls are omitted here for better readability:
 # Create "testproject"
 sechub-api.sh project_create testproject int-test_superadmin
 
-# Assign "test_superadmin" as scan user to our project
+# Assign "int-test_superadmin" as scan user to our project
 sechub-api.sh project_assign_user testproject int-test_superadmin
 
 # List project details

--- a/sechub-doc/src/docs/asciidoc/sechub-quickstart-guide.adoc
+++ b/sechub-doc/src/docs/asciidoc/sechub-quickstart-guide.adoc
@@ -148,7 +148,7 @@ export PATH="`pwd`/sechub-cli/build/go/platform/linux-amd64:`pwd`/sechub-develop
 . Test: List all users as administrator
 
 [NOTE]
-`sechub-api.sh` is a Bash helper script based on `curl` that eases the use of the https://daimler.github.io/sechub/latest/sechub-restapi.html[SecHub server's REST api]. We use it here to get a list of the users.
+`sechub-api.sh` is a helper Bash script based on `curl` that eases the use of the https://daimler.github.io/sechub/latest/sechub-restapi.html[SecHub server REST API]. We use it here to get a list of the users.
 
 [source,bash]
 ----


### PR DESCRIPTION
- added sechub client example
- added create project
- jdk8 -> jdk11
- made more release-agnostic
  (otherwise we would have to update the docs for
   every Debian/CentOS/Fedora/Alpine/Ubuntu release)
- created a build shell script for easy build
- updated buildDocs script to use above

closes #305 