### PR TITLE
Changed default diffie hellman length to 2048 #689

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip

--- a/sechub-pds/src/main/java/com/daimler/sechub/pds/PDSSystemPropertyInjector.java
+++ b/sechub-pds/src/main/java/com/daimler/sechub/pds/PDSSystemPropertyInjector.java
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+package com.daimler.sechub.pds;
+
+import javax.annotation.PostConstruct;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+
+/**
+ * This component injects some special PDS Spring Boot values into corresponding
+ * system properties. So we can configure those parts in our `application.yaml`
+ * file.
+ * 
+ * @author Albert Tregnaghi
+ *
+ */
+@Component
+public class PDSSystemPropertyInjector {
+
+    // see https://github.com/Daimler/sechub/issues/68 for details
+    @PDSMustBeDocumented(value="Define diffie hellman key length, see https://github.com/Daimler/sechub/issues/689 for details",scope="security")
+    @Value("${pds.security.diffiehellman.length}")
+    private String diffieHellmanLength;
+
+    @PostConstruct
+    public void setDiffieHellmanLength() {
+        System.setProperty("jdk.tls.ephemeralDHKeySize", diffieHellmanLength);
+    }
+}

--- a/sechub-pds/src/main/java/com/daimler/sechub/pds/PDSSystemPropertyInjector.java
+++ b/sechub-pds/src/main/java/com/daimler/sechub/pds/PDSSystemPropertyInjector.java
@@ -6,11 +6,10 @@ import javax.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-
 /**
  * This component injects some special PDS Spring Boot values into corresponding
- * system properties. So we can configure those parts in our `application.yaml`
- * file.
+ * JVM system properties. So we can configure those parts in our
+ * `application.yaml` file.
  * 
  * @author Albert Tregnaghi
  *
@@ -18,8 +17,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class PDSSystemPropertyInjector {
 
-    // see https://github.com/Daimler/sechub/issues/68 for details
-    @PDSMustBeDocumented(value="Define diffie hellman key length, see https://github.com/Daimler/sechub/issues/689 for details",scope="security")
+    @PDSMustBeDocumented(value = "Define diffie hellman key length, see https://github.com/Daimler/sechub/issues/689 for details", scope = "security")
     @Value("${pds.security.diffiehellman.length}")
     private String diffieHellmanLength;
 

--- a/sechub-pds/src/main/resources/application.yml
+++ b/sechub-pds/src/main/resources/application.yml
@@ -5,6 +5,10 @@ sechub:
       intranet:
         hostname:
           endswith: intranet.example.org
+pds:          
+  security:
+    diffiehellman:
+      length: 2048 # JDK uses per default 1024, we set here to 2048 which is more secure          
 spring:
   config:
     use-legacy-processing: true # see https://spring.io/blog/2020/08/14/config-file-processing-in-spring-boot-2-4 and  https://stackoverflow.com/questions/64907675/including-profiles-in-spring-boot-2-4-0-version

--- a/sechub-server/src/main/java/com/daimler/sechub/server/SecHubSystemPropertyInjector.java
+++ b/sechub-server/src/main/java/com/daimler/sechub/server/SecHubSystemPropertyInjector.java
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+package com.daimler.sechub.server;
+
+import javax.annotation.PostConstruct;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.daimler.sechub.sharedkernel.MustBeDocumented;
+
+/**
+ * This component injects some special SecHub Spring Boot values into
+ * corresponding system properties. So we can configure those parts in our
+ * `application.yaml` file.
+ * 
+ * @author Albert Tregnaghi
+ *
+ */
+@Component
+public class SecHubSystemPropertyInjector {
+
+    // see https://github.com/Daimler/sechub/issues/68 for details
+    @MustBeDocumented(value="Define diffie hellman key length, see https://github.com/Daimler/sechub/issues/689 for details",scope="security")
+    @Value("${sechub.security.diffiehellman.length}")
+    private String diffieHellmanLength;
+
+    @PostConstruct
+    public void setDiffieHellmanLength() {
+        System.setProperty("jdk.tls.ephemeralDHKeySize", diffieHellmanLength);
+    }
+}

--- a/sechub-server/src/main/java/com/daimler/sechub/server/SecHubSystemPropertyInjector.java
+++ b/sechub-server/src/main/java/com/daimler/sechub/server/SecHubSystemPropertyInjector.java
@@ -10,7 +10,7 @@ import com.daimler.sechub.sharedkernel.MustBeDocumented;
 
 /**
  * This component injects some special SecHub Spring Boot values into
- * corresponding system properties. So we can configure those parts in our
+ * corresponding JVM system properties. So we can configure those parts in our
  * `application.yaml` file.
  * 
  * @author Albert Tregnaghi
@@ -19,8 +19,7 @@ import com.daimler.sechub.sharedkernel.MustBeDocumented;
 @Component
 public class SecHubSystemPropertyInjector {
 
-    // see https://github.com/Daimler/sechub/issues/68 for details
-    @MustBeDocumented(value="Define diffie hellman key length, see https://github.com/Daimler/sechub/issues/689 for details",scope="security")
+    @MustBeDocumented(value = "Define diffie hellman key length, see https://github.com/Daimler/sechub/issues/689 for details", scope = "security")
     @Value("${sechub.security.diffiehellman.length}")
     private String diffieHellmanLength;
 

--- a/sechub-server/src/main/resources/application.yml
+++ b/sechub-server/src/main/resources/application.yml
@@ -5,6 +5,10 @@ sechub:
       intranet:
         hostname:
           endswith: intranet.example.org
+  security:
+    diffiehellman:
+      length: 2048 # JDK uses per default 1024, we set here to 2048 which is more secure
+      
 spring:
   config:
     use-legacy-processing: true # see https://spring.io/blog/2020/08/14/config-file-processing-in-spring-boot-2-4 and  https://stackoverflow.com/questions/64907675/including-profiles-in-spring-boot-2-4-0-version


### PR DESCRIPTION
- introduce SystemPropertyInjector classes and
  special keys for PDS and SecHub server, so configurable
  by `application.yaml` files
- `application.yaml` files do now contain 2048 as default value
- documentation will be generated and points to issue at github
  for details