### PR TITLE
Set up cache for gradle and go 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,6 @@
 
 version: 2
 updates:
-  - package-ecosystem: gradle
-    open-pull-requests-limit: 30
-    directory: /
-    schedule:
-      interval: weekly
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: gradle
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@
 version: 2
 updates:
   - package-ecosystem: gradle
+    open-pull-requests-limit: 30
     directory: /
     schedule:
       interval: weekly

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -27,6 +27,7 @@ jobs:
       with:
         ref: master
     - uses: actions/cache@v2
+      id: gradle-cache
       with:
         path: |
           ~/.gradle/caches
@@ -34,6 +35,15 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
         restore-keys: |
           ${{ runner.os }}-gradle-
+    - uses: actions/cache@v2
+      id: go-cache
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+         ${{ runner.os }}-go-
     # Create temporary local tags, so we build documentation for this tag...
     # The final tag on git server side will be done by the release when the draft is saved as "real" release
     # automatically.

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -34,8 +34,6 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
         restore-keys: |
           ${{ runner.os }}-gradle-
-    
-    
     # Create temporary local tags, so we build documentation for this tag...
     # The final tag on git server side will be done by the release when the draft is saved as "real" release
     # automatically.
@@ -50,7 +48,6 @@ jobs:
     - name: "Temporary tag PDS version: v${{ github.event.inputs.pds-version }}-pds - if defined" 
       if: github.event.inputs.pds-version != ''
       run: git tag v${{ github.event.inputs.pds-version }}-pds
-    
     
     # Build
     - name: Set up JDK 1.8

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -26,6 +26,14 @@ jobs:
       uses: actions/checkout@v2
       with:
         ref: master
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
     
     
     # Create temporary local tags, so we build documentation for this tag...

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -26,24 +26,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         ref: master
-    - uses: actions/cache@v2
-      id: gradle-cache
-      with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
-    - uses: actions/cache@v2
-      id: go-cache
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-         ${{ runner.os }}-go-
     # Create temporary local tags, so we build documentation for this tag...
     # The final tag on git server side will be done by the release when the draft is saved as "real" release
     # automatically.
@@ -65,12 +47,30 @@ jobs:
       with:
         java-version: 8
         distribution: 'adopt'
+    - uses: actions/cache@v2
+      id: gradle-cache
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
         
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
         go-version: 1.15.3
         stable: true
+    - uses: actions/cache@v2
+      id: go-cache
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+         ${{ runner.os }}-go-
     
     - name: Gradle clean
       run: ./gradlew clean

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -46,9 +46,10 @@ jobs:
     
     # Build
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2.1.0
       with:
-        java-version: 1.8
+        java-version: 8
+        distribution: 'adopt'
         
     - name: Set up Go
       uses: actions/setup-go@v2

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -14,10 +14,8 @@ on:
      - v*
 
 jobs:
-  build:
-
+  build: 
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v1
     - name: Set up JDK 1.8
@@ -33,7 +31,6 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
         restore-keys: |
           ${{ runner.os }}-gradle-
-        
     - name: Set up Go
       uses: actions/setup-go@v2
       with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -39,6 +39,14 @@ jobs:
       with:
         go-version: 1.15.3
         stable: true
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
     
     - name: Gradle clean
       run: ./gradlew clean

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,9 +21,10 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2.1.0
       with:
-        java-version: 1.8
+        java-version: 8
+        distribution: 'adopt'
         
     - name: Set up Go
       uses: actions/setup-go@v2

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -25,6 +25,14 @@ jobs:
       with:
         java-version: 8
         distribution: 'adopt'
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
         
     - name: Set up Go
       uses: actions/setup-go@v2

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ buildscript{
 }
 plugins {
     id 'org.asciidoctor.jvm.convert' version '3.1.0'
-    id 'org.asciidoctor.jvm.pdf' version '3.1.0'
+    id 'org.asciidoctor.jvm.pdf' version '3.3.2'
     id 'org.openapi.generator' version '5.2.0'
     id 'org.springframework.boot' version '2.5.2' apply false
 }

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript{
 	}
 }
 plugins {
-    id 'org.asciidoctor.jvm.convert' version '3.1.0'
+    id 'org.asciidoctor.jvm.convert' version '3.3.2'
     id 'org.asciidoctor.jvm.pdf' version '3.3.2'
     id 'org.openapi.generator' version '5.2.0'
     id 'org.springframework.boot' version '2.5.2' apply false

--- a/sechub-server-core/build.gradle
+++ b/sechub-server-core/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     compile(library.flyway)
     
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    compile 'io.micrometer:micrometer-registry-prometheus:1.1.0'
+    compile 'io.micrometer:micrometer-registry-prometheus:1.7.2'
     
     compile project(':sechub-shared-kernel')
     compile project(':sechub-schedule')

--- a/sechub-storage-s3-aws-test/build.gradle
+++ b/sechub-storage-s3-aws-test/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
      // https://mvnrepository.com/artifact/com.adobe.testing/s3mock
     testCompile group: 'com.adobe.testing', name: 's3mock', version: '2.1.36'
-    testCompile group: 'com.adobe.testing', name: 's3mock-junit4', version: '2.1.16'
+    testCompile group: 'com.adobe.testing', name: 's3mock-junit4', version: '2.1.36'
 
     testCompile library.junit
     testCompile library.mockito

--- a/sechub-storage-s3-aws-test/build.gradle
+++ b/sechub-storage-s3-aws-test/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     compile project(':sechub-storage-s3-aws')
 
      // https://mvnrepository.com/artifact/com.adobe.testing/s3mock
-    testCompile group: 'com.adobe.testing', name: 's3mock', version: '2.1.16'
+    testCompile group: 'com.adobe.testing', name: 's3mock', version: '2.1.36'
     testCompile group: 'com.adobe.testing', name: 's3mock-junit4', version: '2.1.16'
 
     testCompile library.junit

--- a/sechub-storage-s3-aws/build.gradle
+++ b/sechub-storage-s3-aws/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compile library.slf4j
     compile project(':sechub-storage-core')
     // https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-s3
-    compile group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.666'
+    compile group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.12.30'
 
 
 }


### PR DESCRIPTION
The set up of caches reduce build time from 18 to 12 min.
This partially treats #688
I have also included dependabot for github-actions dependencies handling. It can also be activated for gradle if you are interested. 
Several gradle dependencies are also updated. 