### PR TITLE
Fix OpenAPI generation in release github action

### DIFF
--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -63,10 +63,10 @@ jobs:
       run: ./gradlew :sechub-cli:buildGo :sechub-cli:testGo
       
     - name: Build Server
-      run: ./gradlew ensureLocalhostCertificate build openapi3 buildDeveloperAdminUI -x :sechub-integrationtest:test -x :sechub-cli:build
+      run: ./gradlew ensureLocalhostCertificate build generateOpenapi buildDeveloperAdminUI -x :sechub-integrationtest:test -x :sechub-cli:build
 
     - name: Generate OpenAPI Java client
-      run: ./gradlew :sechub-client-java:openApiGenerate
+      run: ./gradlew :sechub-client-java:buildJavaClient
 
     - name: Integration test
       run: ./gradlew integrationtest


### PR DESCRIPTION
- add new OpenAPI gradle task names

closes: #740