### PR TITLE
AGPL notice and more

### DIFF
--- a/sechub-pds-examples/gosec/05-start-single-sechub-network-docker-compose.sh
+++ b/sechub-pds-examples/gosec/05-start-single-sechub-network-docker-compose.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+
+SCRIPT_DIR=`dirname $0`
+IMAGE_TYPE="$1"
+
+ENVIRONMENT_FILE=".env"
+
+if [[ ! -f  "$ENVIRONMENT_FILE" ]]
+then
+    echo "Environment file does not exist."
+    echo "Creating default environment file $ENVIRONMENT_FILE for you."
+
+    cp "$SCRIPT_DIR/env-initial" "$SCRIPT_DIR/$ENVIRONMENT_FILE"
+else
+    echo "Using existing environment file: $ENVIRONMENT_FILE."
+fi
+
+if [[ "$IMAGE_TYPE" == "alpine" ]]
+then
+    echo "Starting single Alpine container."
+    docker-compose --file docker-compose_pds_gosec_alpine-external-network.yaml up --build
+else
+    echo "Starting single Ubuntu container."
+    docker-compose --file docker-compose_pds_gosec_ubuntu-external-network.yaml up --build
+fi

--- a/sechub-pds-examples/gosec/70-test.sh
+++ b/sechub-pds-examples/gosec/70-test.sh
@@ -120,7 +120,7 @@ else
     jobUUID=`$pds_api create_job "$PDS_PRODUCT_IDENTFIER" "$sechub_job_uuid" | jq '.jobUUID' | tr -d \"`
 fi
 
-echo "Job created. Job UUID: $jobUUID."
+echo "Job created. Job UUID: $jobUUID"
 
 "$pds_api" upload_zip "$jobUUID" "$file_to_upload"
 

--- a/sechub-pds-examples/gosec/README.adoc
+++ b/sechub-pds-examples/gosec/README.adoc
@@ -66,6 +66,24 @@ or to start the Alpine Linux container:
 docker-compose --file docker-compose_pds_gosec_alpine.yaml up --build
 ----
 
+==== Together with SecHub
+
+The container will be started and attached to the `sechub` Network.
+
+WARNING: Make sure the SecHub container is running.
+
+. Start Ubuntu container:
++
+----
+./05-start-single-sechub-network-docker-compose.sh
+----
++
+or Alpine
++
+----
+05-start-single-sechub-network-docker-compose.sh alpine
+----
+
 === Scan
 
 The steps required to scan with the PDS. Scan manually if you are new to the PDS. Use the script, if you are tired of typing the same commands over and over again.
@@ -445,6 +463,8 @@ NOTE: It is recommended to change the passwords in `.env-cluster`. Other values 
 ----
 
 ==== Object Storage
+
+WARNING: Please beware, that the object storage Docker image contains content licensed under AGPL. For example MinIO, which are **not** covered under the MIT license of this repository.
 
 The cluster uses an object storage to store files. The cluster uses https://min.io/[MinIO] (S3 compatible) to store files. The PDS instance(s) use the object storage to upload files to. Reading, extracting and analysing the files is done in the PDS+GoSec container.
 

--- a/sechub-pds-examples/gosec/docker-compose_pds_gosec_alpine-external-network.yaml
+++ b/sechub-pds-examples/gosec/docker-compose_pds_gosec_alpine-external-network.yaml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: MIT
+
+version: "3"
+services:
+    pds-gosec-alpine:
+        build:
+            args:
+                - BASE_IMAGE=alpine:3.14
+            context: docker/
+            dockerfile: GoSec-Alpine.dockerfile
+        container_name: pds-gosec-alpine
+        env_file:
+            - .env
+        networks:
+            - "sechub"
+
+networks:
+    sechub:
+        external: true
+        name: "sechub"

--- a/sechub-pds-examples/gosec/docker-compose_pds_gosec_ubuntu-external-network.yaml
+++ b/sechub-pds-examples/gosec/docker-compose_pds_gosec_ubuntu-external-network.yaml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: MIT
+
+version: "3"
+services:
+    pds-gosec-ubuntu:
+        build:
+            args:
+                - BASE_IMAGE=ubuntu:focal
+            context: docker/
+            dockerfile: GoSec-Ubuntu.dockerfile
+        container_name: pds-gosec-ubuntu
+        env_file:
+            - .env
+        networks:
+            - "sechub"
+
+networks:
+    sechub:
+        external: true
+        name: "sechub"

--- a/sechub-pds-examples/gosec/docker/GoSec-Alpine.dockerfile
+++ b/sechub-pds-examples/gosec/docker/GoSec-Alpine.dockerfile
@@ -12,14 +12,16 @@ ARG PDS_FOLDER="/pds"
 ARG SCRIPT_FOLDER="/scripts"
 ENV TOOL_FOLDER="/tools"
 ARG WORKSPACE="/workspace"
+ENV DOWNLOAD_FOLDER="/downloads"
+ENV MOCK_FOLDER="$SCRIPT_FOLDER/mocks"
 
 # PDS
-ENV PDS_VERSION=0.23.1
-ARG PDS_CHECKSUM="fb70f3131324f0070631f78229c25168ff50d570a9d481420d095b3bb5aa4a69"
+ENV PDS_VERSION=0.24.0
+ARG PDS_CHECKSUM="ecc69561109ee98a57a087fd9e6a4980a38ac72d07467d6c69579c83c16b3255"
 
 # GoSec
-ARG GOSEC_VERSION="2.8.1"
-ARG GOSEC_CHECKSUM="b9632585292c5ebc749b0afe064661bee7ea422fc7c54a5282a001e52c8ed30d"
+ARG GOSEC_VERSION="2.9.1"
+ARG GOSEC_CHECKSUM="34505685c89f702719177e0c8a2b43907026d8c79b70fbaa76153fbd53603b66"
 
 # Shared volumes
 ENV SHARED_VOLUMES="/shared_volumes"
@@ -38,8 +40,18 @@ RUN apk update --no-cache && \
 COPY gosec.sh $SCRIPT_FOLDER/gosec.sh
 RUN chmod +x $SCRIPT_FOLDER/gosec.sh
 
+COPY gosec_mock.sh $SCRIPT_FOLDER/gosec_mock.sh
+RUN chmod +x $SCRIPT_FOLDER/gosec_mock.sh
+
+# Setup mock product
+RUN mkdir "$MOCK_FOLDER"
+COPY mock.sarif.json "$MOCK_FOLDER"/mock.sarif.json 
+
+# Create download folder
+RUN mkdir "$DOWNLOAD_FOLDER"
+
 # Install GoSec
-RUN cd /tmp && \
+RUN cd "$DOWNLOAD_FOLDER" && \
     # create checksum file
     echo "$GOSEC_CHECKSUM  gosec_${GOSEC_VERSION}_linux_amd64.tar.gz" > gosec_${GOSEC_VERSION}_linux_amd64.tar.gz.sha256sum && \
     # download gosec
@@ -78,7 +90,7 @@ RUN mkdir --parents "$SHARED_VOLUME_UPLOAD_DIR"
 WORKDIR "$WORKSPACE"
 
 # Change owner of tool, workspace and pds folder as well as /run.sh
-RUN chown --recursive gosec:gosec $TOOL_FOLDER $SCRIPT_FOLDER $WORKSPACE $PDS_FOLDER $SHARED_VOLUMES /run.sh
+RUN chown --recursive gosec:gosec $DOWNLOAD_FOLDER $TOOL_FOLDER $SCRIPT_FOLDER $WORKSPACE $PDS_FOLDER $SHARED_VOLUMES /run.sh
 
 # switch from root to non-root user
 USER gosec

--- a/sechub-pds-examples/gosec/docker/gosec.sh
+++ b/sechub-pds-examples/gosec/docker/gosec.sh
@@ -4,3 +4,6 @@
 # GoSec needs access to the go binary
 export PATH="$TOOL_FOLDER/gosec:/usr/local/go/bin:$PATH"
 GO111MODULE=on gosec -fmt=sarif -out="$PDS_JOB_RESULT_FILE" "$PDS_JOB_SOURCECODE_UNZIPPED_FOLDER/..."
+
+# workaround for: https://github.com/securego/gosec/issues/720
+exit 0

--- a/sechub-pds-examples/gosec/docker/gosec_mock.sh
+++ b/sechub-pds-examples/gosec/docker/gosec_mock.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+# SPDX-License-Identifier: MIT
+
+echo "Running PDS GoSec Mock"
+cp "$MOCK_FOLDER/mock.sarif.json" "$PDS_JOB_RESULT_FILE"

--- a/sechub-pds-examples/gosec/docker/mock.sarif.json
+++ b/sechub-pds-examples/gosec/docker/mock.sarif.json
@@ -1,0 +1,197 @@
+{
+	"runs": [
+		{
+			"results": [
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "code/hardcoded_password.go"
+								},
+								"region": {
+									"endColumn": 9,
+									"endLine": 7,
+									"snippet": {
+										"text": "6:     username := \"admin\"\n7:     var password = \"f62e5bcda4fae4f82370da0c6f20697b8f8447ef\"\n8: \n"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 9,
+									"startLine": 7
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "Potential hardcoded credentials"
+					},
+					"ruleId": "G101"
+				},
+				{
+					"level": "error",
+					"locations": [
+						{
+							"physicalLocation": {
+								"artifactLocation": {
+									"uri": "code/sql_injection.go"
+								},
+								"region": {
+									"endColumn": 10,
+									"endLine": 12,
+									"snippet": {
+										"text": "11:     }\n12:     q := fmt.Sprintf(\"SELECT * FROM foo where name = '%s'\", os.Args[1])\n13:     rows, err := db.Query(q)\n"
+									},
+									"sourceLanguage": "go",
+									"startColumn": 10,
+									"startLine": 12
+								}
+							}
+						}
+					],
+					"message": {
+						"text": "SQL string formatting"
+					},
+					"ruleId": "G201",
+					"ruleIndex": 1
+				}
+			],
+			"taxonomies": [
+				{
+					"downloadUri": "https://cwe.mitre.org/data/xml/cwec_v4.4.xml.zip",
+					"guid": "f2856fc0-85b7-373f-83e7-6f8582243547",
+					"informationUri": "https://cwe.mitre.org/data/published/cwe_v4.4.pdf/",
+					"isComprehensive": true,
+					"language": "en",
+					"minimumRequiredLocalizedDataSemanticVersion": "4.4",
+					"name": "CWE",
+					"organization": "MITRE",
+					"releaseDateUtc": "2021-03-15",
+					"shortDescription": {
+						"text": "The MITRE Common Weakness Enumeration"
+					},
+					"taxa": [
+						{
+							"fullDescription": {
+								"text": "The software contains hard-coded credentials, such as a password or cryptographic key, which it uses for its own inbound authentication, outbound communication to external components, or encryption of internal data."
+							},
+							"guid": "93d834a1-2cc5-38db-837f-66dfc7d711cc",
+							"helpUri": "https://cwe.mitre.org/data/definitions/798.html",
+							"id": "798",
+							"shortDescription": {
+								"text": "Use of Hard-coded Credentials"
+							}
+						},
+						{
+							"fullDescription": {
+								"text": "The software constructs all or part of an SQL command using externally-influenced input from an upstream component, but it does not neutralize or incorrectly neutralizes special elements that could modify the intended SQL command when it is sent to a downstream component."
+							},
+							"guid": "6bd55435-166c-3594-bc06-5e0dea916067",
+							"helpUri": "https://cwe.mitre.org/data/definitions/89.html",
+							"id": "89",
+							"shortDescription": {
+								"text": "Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')"
+							}
+						}
+					],
+					"version": "4.4"
+				}
+			],
+			"tool": {
+				"driver": {
+					"guid": "8b518d5f-906d-39f9-894b-d327b1a421c5",
+					"informationUri": "https://github.com/securego/gosec/",
+					"name": "gosec",
+					"rules": [
+						{
+							"defaultConfiguration": {
+								"level": "error"
+							},
+							"fullDescription": {
+								"text": "Potential hardcoded credentials"
+							},
+							"help": {
+								"text": "Potential hardcoded credentials\nSeverity: HIGH\nConfidence: LOW\n"
+							},
+							"id": "G101",
+							"name": "Potential hardcoded credentials",
+							"properties": {
+								"precision": "low",
+								"tags": [
+									"security",
+									"HIGH"
+								]
+							},
+							"relationships": [
+								{
+									"kinds": [
+										"superset"
+									],
+									"target": {
+										"guid": "93d834a1-2cc5-38db-837f-66dfc7d711cc",
+										"id": "798",
+										"toolComponent": {
+											"guid": "f2856fc0-85b7-373f-83e7-6f8582243547",
+											"name": "CWE"
+										}
+									}
+								}
+							],
+							"shortDescription": {
+								"text": "Potential hardcoded credentials"
+							}
+						},
+						{
+							"defaultConfiguration": {
+								"level": "error"
+							},
+							"fullDescription": {
+								"text": "SQL string formatting"
+							},
+							"help": {
+								"text": "SQL string formatting\nSeverity: MEDIUM\nConfidence: HIGH\n"
+							},
+							"id": "G201",
+							"name": "SQL string formatting",
+							"properties": {
+								"precision": "high",
+								"tags": [
+									"security",
+									"MEDIUM"
+								]
+							},
+							"relationships": [
+								{
+									"kinds": [
+										"superset"
+									],
+									"target": {
+										"guid": "6bd55435-166c-3594-bc06-5e0dea916067",
+										"id": "89",
+										"toolComponent": {
+											"guid": "f2856fc0-85b7-373f-83e7-6f8582243547",
+											"name": "CWE"
+										}
+									}
+								}
+							],
+							"shortDescription": {
+								"text": "SQL string formatting"
+							}
+						}
+					],
+					"semanticVersion": "2.8.0",
+					"supportedTaxonomies": [
+						{
+							"guid": "f2856fc0-85b7-373f-83e7-6f8582243547",
+							"name": "CWE"
+						}
+					],
+					"version": "2.8.0"
+				}
+			}
+		}
+	],
+	"$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+	"version": "2.1.0"
+}

--- a/sechub-pds-examples/gosec/docker/pds-config.json
+++ b/sechub-pds-examples/gosec/docker/pds-config.json
@@ -7,7 +7,13 @@
             "id" : "PDS_GOSEC",
             "path" : "/scripts/gosec.sh",
             "scanType" : "codeScan",
-            "description" : "Runs gosec"
+            "description" : "Runs the sechurity checker gosec."
+        },
+        {
+            "id" : "PDS_GOSEC_MOCK",
+            "path" : "/scripts/gosec_mock.sh",
+            "scanType" : "codeScan",
+            "description" : "Runs gosec mock. It returns a fixed result file."
         }
     ]
 }

--- a/sechub-pds-examples/gosec/helm/pds-gosec/Chart.yaml
+++ b/sechub-pds-examples/gosec/helm/pds-gosec/Chart.yaml
@@ -4,12 +4,15 @@ apiVersion: v2
 name: pds-gosec
 description: The GoSec + PDS as Helm chart for Kubernetes
 
+maintainers:
+  - name: Jeremias Eppler
+
 type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -17,4 +20,4 @@ version: 0.2.1
 # It is recommended to use it with quotes.
 #
 # The appVersion corresponds to the deployed PDS version.
-appVersion: "0.23.1"
+appVersion: "0.24.0"

--- a/sechub-pds-examples/gosec/helm/pds-gosec/LICENSE
+++ b/sechub-pds-examples/gosec/helm/pds-gosec/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Daimler TSS GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sechub-pds-examples/gosec/helm/pds-gosec/README.md
+++ b/sechub-pds-examples/gosec/helm/pds-gosec/README.md
@@ -1,0 +1,3 @@
+# GoSec + PDS
+
+This Helm chart enables one to deploy [GoSec](https://securego.io/) and the [SecHub Product Delegation Server (PDS)](https://daimler.github.io/sechub/latest/sechub-product-delegation-server.html) into a Kubernetes environment. It is recommended to use GoSec + PDS together with [SecHub](https://daimler.github.io/sechub/).


### PR DESCRIPTION
Fixes multiple issues:

- Make PDS+GoSec part of the SecHub network #872
- Update PDS to 0.24.0 #870
- Update Go in Ubuntu to 1.7.2 #870
- Update GoSec to 2.9.1 #870
- Download dependencies into download folder #822
- Add AGPL notice for MinIO #821
- Add maintainers, README.md and LICENSE file for Helm chart #779
- Introduces a PDS_GOSEC_MOCK product #871

closes: #872
closes: #871 
closes: #870
closes: #822
closes: #821 
closes: #779