### PR TITLE
Changed mock handling for PDS #869, #881

### DIFF
--- a/sechub-adapter-pds/src/main/java/com/daimler/sechub/adapter/pds/DelegatingMockablePDSAdapterV1.java
+++ b/sechub-adapter-pds/src/main/java/com/daimler/sechub/adapter/pds/DelegatingMockablePDSAdapterV1.java
@@ -3,6 +3,7 @@ package com.daimler.sechub.adapter.pds;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
@@ -11,9 +12,10 @@ import com.daimler.sechub.adapter.AdapterException;
 import com.daimler.sechub.adapter.AdapterProfiles;
 import com.daimler.sechub.adapter.AdapterRuntimeContext;
 import com.daimler.sechub.adapter.mock.MockedAdapter;
+import com.daimler.sechub.adapter.mock.MockedAdapterSetupService;
 
 /**
- * Special adapter which CAN be mocked but is per default using real product
+ * Special adapter which is per default mocked, but can be defined to use real product
  * (PDS). So we can use started PDS integration test server in our tests
  * 
  * @author Albert Tregnaghi
@@ -23,15 +25,18 @@ import com.daimler.sechub.adapter.mock.MockedAdapter;
 @Component
 public class DelegatingMockablePDSAdapterV1 extends AbstractAdapter<PDSAdapterContext, PDSAdapterConfig> implements MockedAdapter<PDSAdapterConfig>, PDSAdapter {
 
+    public static final String JOB_PARAMETER_KEY__PDS_MOCKING_DISABLED = "pds.mocking.disabled";
+
     private static final Logger LOG = LoggerFactory.getLogger(DelegatingMockablePDSAdapterV1.class);
 
     MockedPDSAdapterV1 mockedPdsAdapterV1;
 
     PDSAdapterV1 realPdsAdapterV1;
 
-    public DelegatingMockablePDSAdapterV1() {
-        /* to have both worlds (mocked_products + real_products), we instanciate this here directly */
-        mockedPdsAdapterV1 = new MockedPDSAdapterV1();
+    @Autowired
+    public DelegatingMockablePDSAdapterV1(MockedAdapterSetupService setupService) {
+        /* to have both worlds (mocked_products + real_products), we instantiate this here directly */
+        mockedPdsAdapterV1 = new MockedPDSAdapterV1(setupService);
         realPdsAdapterV1 = new PDSAdapterV1();
     }
 
@@ -42,12 +47,12 @@ public class DelegatingMockablePDSAdapterV1 extends AbstractAdapter<PDSAdapterCo
 
     @Override
     protected String execute(PDSAdapterConfig config, AdapterRuntimeContext runtimeContext) throws AdapterException {
-        String mocked = config.getJobParameters().get("mocked");
-        boolean mockWanted = Boolean.parseBoolean(mocked);
+        String mockingDisabled = config.getJobParameters().get(JOB_PARAMETER_KEY__PDS_MOCKING_DISABLED);
+        boolean useMock= !Boolean.parseBoolean(mockingDisabled);
+        
+        LOG.info("execution starting, using mocked adapter={}", useMock);
 
-        LOG.info("execution starting, using mocked={}", mockWanted);
-
-        if (mockWanted) {
+        if (useMock) {
             return mockedPdsAdapterV1.execute(config, runtimeContext);
         }
         return realPdsAdapterV1.execute(config, runtimeContext);

--- a/sechub-adapter-pds/src/main/java/com/daimler/sechub/adapter/pds/MockedPDSAdapterV1.java
+++ b/sechub-adapter-pds/src/main/java/com/daimler/sechub/adapter/pds/MockedPDSAdapterV1.java
@@ -2,6 +2,7 @@
 package com.daimler.sechub.adapter.pds;
 
 import com.daimler.sechub.adapter.mock.AbstractMockedAdapter;
+import com.daimler.sechub.adapter.mock.MockedAdapterSetupService;
 
 /**
  * Special mocked adapter. It is not marked as component, so not collected by spring. See {@link DelegatingMockablePDSAdapterV1}
@@ -14,7 +15,11 @@ public class MockedPDSAdapterV1 extends AbstractMockedAdapter<PDSAdapterContext,
 		implements PDSAdapter {
 
 
-	protected void executeMockSanityCheck(PDSAdapterConfig config) {
+	public MockedPDSAdapterV1(MockedAdapterSetupService setupService) {
+        this.setupService=setupService;
+    }
+
+    protected void executeMockSanityCheck(PDSAdapterConfig config) {
 	}
 	
 	@Override

--- a/sechub-adapter-pds/src/test/java/com/daimler/sechub/adapter/pds/DelegatingMockablePDSAdapterV1Test.java
+++ b/sechub-adapter-pds/src/test/java/com/daimler/sechub/adapter/pds/DelegatingMockablePDSAdapterV1Test.java
@@ -1,0 +1,69 @@
+package com.daimler.sechub.adapter.pds;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.daimler.sechub.adapter.AdapterRuntimeContext;
+import com.daimler.sechub.adapter.mock.MockedAdapterSetupService;
+
+class DelegatingMockablePDSAdapterV1Test {
+    
+    DelegatingMockablePDSAdapterV1 adapterToTest;
+    private AdapterRuntimeContext runtimeContext;
+    private PDSAdapterConfig config;
+    private UUID jobUUID;
+    private MockedAdapterSetupService setupService;
+    private PDSAdapterV1 realPdsAdapter;
+    
+    @BeforeEach
+    void beforeEach() {
+        setupService = mock(MockedAdapterSetupService.class);
+        adapterToTest = new DelegatingMockablePDSAdapterV1(setupService);
+        // we simulate real PDS adapter - mocked adapter can be used as is*/
+        realPdsAdapter=mock(PDSAdapterV1.class);
+        adapterToTest.realPdsAdapterV1=realPdsAdapter;
+        
+        jobUUID = UUID.randomUUID();
+        
+        config = mock(PDSAdapterConfig.class);
+        when(config.getSecHubJobUUID()).thenReturn(jobUUID);
+        
+        runtimeContext= new AdapterRuntimeContext();
+    }
+    
+    @Test
+    void when_nothing_special_real_pds_adapter_is_not_used() throws Exception {
+        when(setupService.getSetupFor(any(),any())).thenReturn(null);
+        /* execute */
+        String result = adapterToTest.execute(config,runtimeContext);
+        
+        /* test */
+        verify(realPdsAdapter,never()).execute(config, runtimeContext);
+        assertEquals("",result); // no setup defined, so mocked adapter does always return ""
+    }
+    
+    @Test
+    void when_config_pds_mocking_disabled_real_pds_adapter_is_used() throws Exception {
+        Map<String, String> map = new LinkedHashMap<>();
+        map.put("pds.mocking.disabled","true");
+        
+        /*prepare */
+        when(realPdsAdapter.execute(any(), any())).thenReturn("pseudo-test-result");
+        when(config.getJobParameters()).thenReturn(map);
+        /* execute */
+        String result = adapterToTest.execute(config,runtimeContext);
+        
+        /* test */
+        verify(realPdsAdapter,times(1)).execute(config, runtimeContext);
+        assertEquals("pseudo-test-result",result);
+    }
+
+}

--- a/sechub-adapter/src/main/java/com/daimler/sechub/adapter/mock/AbstractMockedAdapter.java
+++ b/sechub-adapter/src/main/java/com/daimler/sechub/adapter/mock/AbstractMockedAdapter.java
@@ -67,7 +67,7 @@ public abstract class AbstractMockedAdapter<A extends AdapterContext<C>, C exten
     private boolean mockSanityCheckEnabled;
 
     @Autowired
-    private MockedAdapterSetupService setupService;
+    protected MockedAdapterSetupService setupService;
 
     @Override
     protected final String getAPIPrefix() {

--- a/sechub-integrationtest/src/main/java/com/daimler/sechub/integrationtest/internal/IntegrationTestDefaultExecutorConfigurations.java
+++ b/sechub-integrationtest/src/main/java/com/daimler/sechub/integrationtest/internal/IntegrationTestDefaultExecutorConfigurations.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import com.daimler.sechub.adapter.pds.DelegatingMockablePDSAdapterV1;
 import com.daimler.sechub.integrationtest.api.PDSIntTestProductIdentifier;
 import com.daimler.sechub.integrationtest.api.TestAPI;
 import com.daimler.sechub.integrationtest.api.TestExecutorProductIdentifier;
@@ -126,7 +127,7 @@ public class IntegrationTestDefaultExecutorConfigurations {
 
     private static TestExecutorConfig definePDSScan(String variant, boolean credentialsAsEnvEntries, String productIdentifierId, StorageType storageType,
             TestExecutorProductIdentifier sechubProductIdentifier) {
-        TestExecutorConfig config = createTestEditorConfig();
+        TestExecutorConfig config = createTestExecutorConfig();
 
         String middleConfigName = sechubProductIdentifier.name().toLowerCase() + "_";
 
@@ -167,7 +168,7 @@ public class IntegrationTestDefaultExecutorConfigurations {
     }
 
     private static TestExecutorConfig defineNetsparkerConfig() {
-        TestExecutorConfig config = createTestEditorConfig();
+        TestExecutorConfig config = createTestExecutorConfig();
         config.enabled = true;
         config.executorVersion = 1;
         config.productIdentifier = TestExecutorProductIdentifier.NETSPARKER.name();
@@ -180,7 +181,7 @@ public class IntegrationTestDefaultExecutorConfigurations {
     }
 
     private static TestExecutorConfig defineCheckmarxConfig() {
-        TestExecutorConfig config = createTestEditorConfig();
+        TestExecutorConfig config = createTestExecutorConfig();
         config.enabled = true;
         config.executorVersion = 1;
         config.productIdentifier = TestExecutorProductIdentifier.CHECKMARX.name();
@@ -204,7 +205,7 @@ public class IntegrationTestDefaultExecutorConfigurations {
     }
 
     private static TestExecutorConfig defineNessusConfig() {
-        TestExecutorConfig config = createTestEditorConfig();
+        TestExecutorConfig config = createTestExecutorConfig();
         config.enabled = true;
         config.executorVersion = 1;
         config.productIdentifier = TestExecutorProductIdentifier.NESSUS.name();
@@ -219,9 +220,10 @@ public class IntegrationTestDefaultExecutorConfigurations {
         return config;
     }
 
-    private static TestExecutorConfig createTestEditorConfig() {
+    private static TestExecutorConfig createTestExecutorConfig() {
         TestExecutorConfig testExecutorConfig = new TestExecutorConfig();
         registeredConfigurations.add(testExecutorConfig);
+        testExecutorConfig.setup.jobParameters.add(new TestExecutorSetupJobParam(DelegatingMockablePDSAdapterV1.JOB_PARAMETER_KEY__PDS_MOCKING_DISABLED, "true"));
         return testExecutorConfig;
     }
 


### PR DESCRIPTION
- integration tests do now use "pds.mocking.disabled"
  job parameter with "true"
- only when "pds.mocking.disabled" a real PDS adapter
  is used, otherwise mock variant is used when
  spring boot profile "mocked_products" is set
- setupService is now set to created mock and
  fixes #881
- fixes #869 