### PR TITLE
introduce check alive via GET

### DIFF
--- a/sechub-pds/src/main/java/com/daimler/sechub/pds/monitoring/PDSAnonymousCheckAliveRestController.java
+++ b/sechub-pds/src/main/java/com/daimler/sechub/pds/monitoring/PDSAnonymousCheckAliveRestController.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 package com.daimler.sechub.pds.monitoring;
 
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,9 +15,10 @@ public class PDSAnonymousCheckAliveRestController {
 
 	/* @formatter:off */
 	@UseCaseAnonymousCheckAlive(@PDSStep(name="rest call",description = "anybody - even anonymous - checks server alive.",number=1))
-	@RequestMapping(path = PDSAPIConstants.API_ANONYMOUS + "check/alive", method = RequestMethod.HEAD)
-	public void checkAlive() {
-	    /* do nothing here - its just a HEAD request */
+	@RequestMapping(path = PDSAPIConstants.API_ANONYMOUS + "check/alive", method = {RequestMethod.GET, RequestMethod.HEAD}, produces = {MediaType.APPLICATION_JSON_VALUE})
+	public String checkAlive() {
+	    /* empty result, only HTTP STATUS 200 OK is of interest */
+	    return "";
 	}
 	/* @formatter:on */
 }

--- a/sechub-pds/src/test/java/com/daimler/sechub/pds/monitoring/PDSAnonymousCheckAliveRestControllerMockTest.java
+++ b/sechub-pds/src/test/java/com/daimler/sechub/pds/monitoring/PDSAnonymousCheckAliveRestControllerMockTest.java
@@ -40,13 +40,29 @@ public class PDSAnonymousCheckAliveRestControllerMockTest {
 	private MockMvc mockMvc;
 
 	@Test
-    public void a_get_execution_status_calls_executionService_and_returns_result() throws Exception {
+    public void calling_check_alive_head_returns_HTTP_200() throws Exception {
         /* prepare */
         
         /* execute + test */
         /* @formatter:off */
         this.mockMvc.perform(
                 head(https(PORT_USED).pds().buildAnonymousCheckAlive())
+                ).
+                    andExpect(status().isOk()
+                );
+
+        /* @formatter:on */
+
+    }
+	
+    @Test
+    public void calling_check_alive_get_returns_HTTP_200() throws Exception {
+        /* prepare */
+        
+        /* execute + test */
+        /* @formatter:off */
+        this.mockMvc.perform(
+                get(https(PORT_USED).pds().buildAnonymousCheckAlive())
                 ).
                     andExpect(status().isOk()
                 );


### PR DESCRIPTION
Extend the check alive call to include GET as a possible method. This is important for readiness and liveliness probes in Kubernetes.

closes: #918