### PR TITLE
Upgrade GoSec + PDS

### DIFF
--- a/sechub-pds-solutions/gosec/01-start-single-docker-compose.sh
+++ b/sechub-pds-solutions/gosec/01-start-single-docker-compose.sh
@@ -19,8 +19,8 @@ fi
 if [[ "$IMAGE_TYPE" == "alpine" ]]
 then
     echo "Starting single Alpine container."
-    docker-compose --file docker-compose_pds_gosec_alpine.yaml up --build
+    docker-compose --file docker-compose_pds_gosec_alpine.yaml up --build --remove-orphans
 else
     echo "Starting single Ubuntu container."
-    docker-compose --file docker-compose_pds_gosec_ubuntu.yaml up --build
+    docker-compose --file docker-compose_pds_gosec_ubuntu.yaml up --build --remove-orphans
 fi

--- a/sechub-pds-solutions/gosec/05-start-single-sechub-network-docker-compose.sh
+++ b/sechub-pds-solutions/gosec/05-start-single-sechub-network-docker-compose.sh
@@ -19,8 +19,8 @@ fi
 if [[ "$IMAGE_TYPE" == "alpine" ]]
 then
     echo "Starting single Alpine container."
-    docker-compose --file docker-compose_pds_gosec_alpine-external-network.yaml up --build
+    docker-compose --file docker-compose_pds_gosec_alpine-external-network.yaml up --build --remove-orphans
 else
     echo "Starting single Ubuntu container."
-    docker-compose --file docker-compose_pds_gosec_ubuntu-external-network.yaml up --build
+    docker-compose --file docker-compose_pds_gosec_ubuntu-external-network.yaml up --build --remove-orphans
 fi

--- a/sechub-pds-solutions/gosec/10-create-ubuntu-image.sh
+++ b/sechub-pds-solutions/gosec/10-create-ubuntu-image.sh
@@ -23,5 +23,7 @@ then
 fi
 
 echo ">> Base image: $BASE_IMAGE"
-docker build --pull --no-cache --build-arg BASE_IMAGE=$BASE_IMAGE --tag "$REGISTRY:$VERSION" --file docker/GoSec-Ubuntu.dockerfile docker/
+docker build --pull --no-cache \
+  --build-arg BASE_IMAGE=$BASE_IMAGE \
+  --tag "$REGISTRY:$VERSION" --file docker/GoSec-Ubuntu.dockerfile docker/
 docker tag "$REGISTRY:$VERSION" "$REGISTRY:latest"

--- a/sechub-pds-solutions/gosec/10-create-ubuntu-image.sh
+++ b/sechub-pds-solutions/gosec/10-create-ubuntu-image.sh
@@ -3,27 +3,50 @@
 
 REGISTRY="$1"
 VERSION="$2"
-BASE_IMAGE="$3"
+BASE_IMAGE="$3"  # optional
+DEFAULT_BASE_IMAGE="ubuntu:focal"
 
-if [[ -z "$REGISTRY" ]]
-then
-  echo "Please provide a docker registry server."
+usage() {
+  cat - <<EOF
+usage: $0 <docker registry> <version tag> [<base image>]
+Builds a docker image of SecHub PDS with GoSec
+for <docker registry> with tag <version tag>.
+Optional: <base image> ; defaults to $DEFAULT_BASE_IMAGE
+
+Additionally these environment variables can be defined:
+- PDS_VERSION - version of SecHub PDS to use. E.g. 0.24.0
+- GOSEC_VERSION - GoSec version to use. E.g. 2.9.5
+EOF
+}
+
+if [[ -z "$REGISTRY" ]] ; then
+  echo "Please provide a docker registry server as 1st parameter."
   exit 1
 fi
 
-if [[ -z "$VERSION" ]]
-then
-  echo "Please provide a version for the container."
+if [[ -z "$VERSION" ]] ; then
+  echo "Please provide a version for the container as 2nd parameter."
   exit 1
 fi
 
-if [[ -z "$BASE_IMAGE" ]]
-then
-    BASE_IMAGE="ubuntu:focal"
+if [[ -z "$BASE_IMAGE" ]]; then
+    BASE_IMAGE="$DEFAULT_BASE_IMAGE"
 fi
 
+BUILD_ARGS="--build-arg BASE_IMAGE=$BASE_IMAGE"
 echo ">> Base image: $BASE_IMAGE"
-docker build --pull --no-cache \
-  --build-arg BASE_IMAGE=$BASE_IMAGE \
-  --tag "$REGISTRY:$VERSION" --file docker/GoSec-Ubuntu.dockerfile docker/
+
+if [[ ! -z "$PDS_VERSION" ]] ; then
+    echo ">> SecHub PDS version: $PDS_VERSION"
+    BUILD_ARGS+=" --build-arg PDS_VERSION=$PDS_VERSION"
+fi
+
+if [[ ! -z "$GOSEC_VERSION" ]] ; then
+    echo ">> GoSec version: $GOSEC_VERSION"
+    BUILD_ARGS+=" --build-arg GOSEC_VERSION=$GOSEC_VERSION"
+fi
+
+docker build --pull --no-cache $BUILD_ARGS \
+       --tag "$REGISTRY:$VERSION" \
+       --file docker/GoSec-Ubuntu.dockerfile docker/
 docker tag "$REGISTRY:$VERSION" "$REGISTRY:latest"

--- a/sechub-pds-solutions/gosec/50-start-multiple-docker-compose.sh
+++ b/sechub-pds-solutions/gosec/50-start-multiple-docker-compose.sh
@@ -24,4 +24,4 @@ else
     echo "Starting cluster of $REPLICAS containers."
 fi
 
-docker-compose --file docker-compose_pds_gosec_cluster.yaml up --scale pds-gosec=$REPLICAS --build
+docker-compose --file docker-compose_pds_gosec_cluster.yaml up --scale pds-gosec=$REPLICAS --build --remove-orphans

--- a/sechub-pds-solutions/gosec/51-start-multiple-object-storage-docker-compose.sh
+++ b/sechub-pds-solutions/gosec/51-start-multiple-object-storage-docker-compose.sh
@@ -25,4 +25,4 @@ else
     echo "Starting cluster of $REPLICAS containers."
 fi
 
-docker-compose --file docker-compose_pds_gosec_cluster_object_storage.yaml up --scale pds-gosec=$REPLICAS --build
+docker-compose --file docker-compose_pds_gosec_cluster_object_storage.yaml up --scale pds-gosec=$REPLICAS --build --remove-orphans

--- a/sechub-pds-solutions/gosec/70-test.sh
+++ b/sechub-pds-solutions/gosec/70-test.sh
@@ -150,6 +150,12 @@ do
     status=`$pds_api job_status "$jobUUID" | jq '.state' | tr -d \"`
     echo "Job status: $status"
 
+    if (( $retries % 10 == 0 ))
+    then
+        printf "\n# Job output stream\n"
+        "$pds_api" job_stream_output "$jobUUID"
+    fi
+
     ((retries--))
     sleep 0.5s
 done

--- a/sechub-pds-solutions/gosec/docker/GoSec-Alpine.dockerfile
+++ b/sechub-pds-solutions/gosec/docker/GoSec-Alpine.dockerfile
@@ -17,11 +17,10 @@ ENV MOCK_FOLDER="$SCRIPT_FOLDER/mocks"
 
 # PDS
 ENV PDS_VERSION=0.24.0
-ARG PDS_CHECKSUM="ecc69561109ee98a57a087fd9e6a4980a38ac72d07467d6c69579c83c16b3255"
 
 # GoSec
-ARG GOSEC_VERSION="2.9.3"
-ARG GOSEC_CHECKSUM="74e8d3ab4e57fef8d78825f73d63d2cc736f356c70319a7c3f47f69bde8c32ad"
+ARG GOSEC_VERSION="2.9.5"
+ARG GOSEC_CHECKSUM="524330ccda004a9af0ef1b78b712df02144a307a15b57a6528f12762f73c8d8e"
 
 # Shared volumes
 ENV SHARED_VOLUMES="/shared_volumes"
@@ -33,63 +32,67 @@ ENV SHARED_VOLUME_UPLOAD_DIR="$SHARED_VOLUMES/uploads"
 RUN addgroup --gid 2323 gosec \
      && adduser --uid 2323 --disabled-password --ingroup gosec gosec
 
+# Create folders & change owner of folders
+RUN mkdir --parents "$PDS_FOLDER" "$SCRIPT_FOLDER" "$TOOL_FOLDER" "$WORKSPACE" "$DOWNLOAD_FOLDER" "MOCK_FOLDER" "$SHARED_VOLUME_UPLOAD_DIR" && \
+    chown --recursive gosec:gosec "$DOWNLOAD_FOLDER" "$TOOL_FOLDER" "$WORKSPACE" "$SCRIPT_FOLDER" "$PDS_FOLDER" "$SHARED_VOLUMES"
+
 RUN apk update --no-cache && \
     apk add --no-cache go openjdk11-jre-headless wget unzip tar
 
-# Create script folder
-COPY gosec.sh $SCRIPT_FOLDER/gosec.sh
-RUN chmod +x $SCRIPT_FOLDER/gosec.sh
+# Switch from root to non-root user
+USER gosec
 
-COPY gosec_mock.sh $SCRIPT_FOLDER/gosec_mock.sh
-RUN chmod +x $SCRIPT_FOLDER/gosec_mock.sh
+# Copy mock file
+COPY mock.sarif.json "$MOCK_FOLDER"/mock.sarif.json
 
-# Setup mock product
-RUN mkdir "$MOCK_FOLDER"
-COPY mock.sarif.json "$MOCK_FOLDER"/mock.sarif.json 
-
-# Create download folder
-RUN mkdir "$DOWNLOAD_FOLDER"
+# Copy PDS configfile
+COPY pds-config.json /$PDS_FOLDER/pds-config.json
 
 # Install GoSec
 RUN cd "$DOWNLOAD_FOLDER" && \
     # create checksum file
     echo "$GOSEC_CHECKSUM  gosec_${GOSEC_VERSION}_linux_amd64.tar.gz" > gosec_${GOSEC_VERSION}_linux_amd64.tar.gz.sha256sum && \
     # download gosec
-    wget https://github.com/securego/gosec/releases/download/v${GOSEC_VERSION}/gosec_${GOSEC_VERSION}_linux_amd64.tar.gz && \
+    wget --no-verbose https://github.com/securego/gosec/releases/download/v${GOSEC_VERSION}/gosec_${GOSEC_VERSION}_linux_amd64.tar.gz && \
     # verify checksum
     sha256sum -c "gosec_${GOSEC_VERSION}_linux_amd64.tar.gz.sha256sum" && \
     # create gosec folder
-    mkdir -p "$TOOL_FOLDER/gosec" && \
+    mkdir --parents "$TOOL_FOLDER/gosec" && \
     # unpack gosec
     tar --extract --ungzip --file "gosec_${GOSEC_VERSION}_linux_amd64.tar.gz" --directory "$TOOL_FOLDER/gosec" && \
     # Remove gosec tar.gz
     rm "gosec_${GOSEC_VERSION}_linux_amd64.tar.gz"
 
 # Install the Product Delegation Server (PDS)
-RUN mkdir --parents "$PDS_FOLDER" && \
-    cd /pds && \
-    # create checksum file
-    echo "$PDS_CHECKSUM  sechub-pds-$PDS_VERSION.jar" > sechub-pds-$PDS_VERSION.jar.sha256sum && \
+RUN cd /pds && \
+    # download checksum file
+    wget --no-verbose "https://github.com/Daimler/sechub/releases/download/v$PDS_VERSION-pds/sechub-pds-$PDS_VERSION.jar.sha256sum" && \
     # download pds
-    wget "https://github.com/Daimler/sechub/releases/download/v$PDS_VERSION-pds/sechub-pds-$PDS_VERSION.jar" && \
+    wget --no-verbose "https://github.com/Daimler/sechub/releases/download/v$PDS_VERSION-pds/sechub-pds-$PDS_VERSION.jar" && \
     # verify that the checksum and the checksum of the file are same
     sha256sum -c sechub-pds-$PDS_VERSION.jar.sha256sum
 
-# Copy PDS configfile
-COPY pds-config.json /$PDS_FOLDER/pds-config.json
-
 # Copy run script into container
 COPY run.sh /run.sh
-RUN chmod +x /run.sh
 
-# Create shared volumes and upload dir
-RUN mkdir --parents "$SHARED_VOLUME_UPLOAD_DIR"
+# Copy scripts
+COPY gosec.sh $SCRIPT_FOLDER/gosec.sh
+COPY gosec_mock.sh $SCRIPT_FOLDER/gosec_mock.sh
 
-# Create the PDS workspace
+# Switch back to root
+USER root
+
+# Change owner of run.sh
+RUN chown gosec:gosec /run.sh 
+
+# Set execute permissions for scripts
+RUN chmod +x /run.sh $SCRIPT_FOLDER/gosec.sh $SCRIPT_FOLDER/gosec_mock.sh
+
+# Switch from root to non-root user
+USER gosec
+
+# Set workspace
 WORKDIR "$WORKSPACE"
-
-# Change owner of tool, workspace and pds folder as well as /run.sh
-RUN chown --recursive gosec:gosec $DOWNLOAD_FOLDER $TOOL_FOLDER $SCRIPT_FOLDER $WORKSPACE $PDS_FOLDER $SHARED_VOLUMES /run.sh
 
 # switch from root to non-root user
 USER gosec

--- a/sechub-pds-solutions/gosec/docker/GoSec-Ubuntu.dockerfile
+++ b/sechub-pds-solutions/gosec/docker/GoSec-Ubuntu.dockerfile
@@ -7,72 +7,72 @@ FROM ${BASE_IMAGE}
 # The remaining arguments need to be placed after the `FROM`
 # See: https://ryandaniels.ca/blog/docker-dockerfile-arg-from-arg-trouble/
 
-# User
-ENV USER="gosec"
+LABEL maintainer="SecHub FOSS Team"
 
-# Folders
+# Build args
+ARG GO="go1.17.5.linux-amd64.tar.gz"
+ARG GOSEC_VERSION="2.9.5"
 ARG PDS_FOLDER="/pds"
+ARG PDS_VERSION="0.24.0"
 ARG SCRIPT_FOLDER="/scripts"
-ENV TOOL_FOLDER="/tools"
 ARG WORKSPACE="/workspace"
+
+# env vars in container:
 ENV DOWNLOAD_FOLDER="/downloads"
 ENV MOCK_FOLDER="$SCRIPT_FOLDER/mocks"
-
-# PDS
-ENV PDS_VERSION=0.24.0
-
-# Go
-ARG GO="go1.17.5.linux-amd64.tar.gz"
-ARG GO_CHECKSUM="bd78114b0d441b029c8fe0341f4910370925a4d270a6a590668840675b0c653e"
-
-# GoSec
-ARG GOSEC_VERSION="2.9.5"
-
-# Shared volumes
+ENV PDS_VERSION="${PDS_VERSION}"
 ENV SHARED_VOLUMES="/shared_volumes"
 ENV SHARED_VOLUME_UPLOAD_DIR="$SHARED_VOLUMES/uploads"
+ENV TOOL_FOLDER="/tools"
+ENV USER="gosec"
+ENV UID="2323"
+ENV GID="${UID}"
 
 # non-root user
 # using fixed group and user ids
 # gosec needs a home directory for the cache
-RUN groupadd --gid 2323 "$USER" \
-     && useradd --uid 2323 --no-log-init --create-home --gid "$USER" "$USER"
+RUN groupadd --gid "$GID" "$USER" && \
+    useradd --uid "$UID" --gid "$GID" --no-log-init --create-home "$USER"
 
 # Create folders & change owner of folders
 RUN mkdir --parents "$PDS_FOLDER" "$SCRIPT_FOLDER" "$TOOL_FOLDER" "$WORKSPACE" "$DOWNLOAD_FOLDER" "MOCK_FOLDER" "$SHARED_VOLUME_UPLOAD_DIR" && \
-    chown --recursive "$USER:$USER" "$DOWNLOAD_FOLDER" "$TOOL_FOLDER" "$WORKSPACE" "$SCRIPT_FOLDER" "$PDS_FOLDER" "$SHARED_VOLUMES"
+    chown --recursive "$USER:$USER" "$DOWNLOAD_FOLDER" "$TOOL_FOLDER" "$SCRIPT_FOLDER" "$WORKSPACE" "$SHARED_VOLUMES"
 
-# Update image and install dependencies
-ENV DEBIAN_FRONTEND noninteractive
+# Copy mock file
+COPY mock.sarif.json "$MOCK_FOLDER"/mock.sarif.json
+# Copy PDS configfile
+COPY pds-config.json "$PDS_FOLDER"/pds-config.json
+# Copy GoSec stuff
+COPY gosec.sh "$SCRIPT_FOLDER"/gosec.sh
+COPY gosec_mock.sh "$SCRIPT_FOLDER"/gosec_mock.sh
+# Copy run script into container
+COPY run.sh /run.sh
 
-RUN apt-get update && \
+# Set execute permissions for scripts
+RUN chmod +x /run.sh "$SCRIPT_FOLDER"/gosec.sh "$SCRIPT_FOLDER"/gosec_mock.sh
+
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
     apt-get upgrade --assume-yes && \
-    apt-get install --assume-yes wget openjdk-11-jre-headless && \
+    apt-get install --assume-yes w3m wget openjdk-11-jre-headless && \
     apt-get clean
 
 # Install Go
 RUN cd "$DOWNLOAD_FOLDER" && \
+    # Get checksum from Go download site
+    GO_CHECKSUM=`w3m https://go.dev/dl/ | grep go1.17.5.linux-amd64.tar.gz | tail -1 | awk '{print $6}'` && \
     # create checksum file
-    echo "$GO_CHECKSUM $GO" > $GO.sha256sum && \
+    echo "$GO_CHECKSUM $GO" > "$GO.sha256sum" && \
     # download Go
-    wget --no-verbose https://dl.google.com/go/${GO} && \
+    wget --no-verbose https://go.dev/dl/"${GO}" && \
     # verify that the checksum and the checksum of the file are same
-    sha256sum --check $GO.sha256sum && \
+    sha256sum --check "$GO.sha256sum" && \
     # extract Go
-    tar --extract --file $GO --directory "/usr/local/" && \
+    tar --extract --file "$GO" --directory /usr/local/ && \
     # remove go tar.gz
-    rm $GO && \
+    rm "$GO" && \
     # add Go to path
     echo 'export PATH="/usr/local/go/bin:$PATH":' >> /root/.bashrc
-
-# Switch from root to non-root user
-USER "$USER"
-
-# Copy mock file
-COPY mock.sarif.json "$MOCK_FOLDER"/mock.sarif.json
-
-# Copy PDS configfile
-COPY pds-config.json /$PDS_FOLDER/pds-config.json
 
 # Install GoSec
 RUN cd "$DOWNLOAD_FOLDER" && \
@@ -89,27 +89,14 @@ RUN cd "$DOWNLOAD_FOLDER" && \
     # Remove gosec tar.gz
     rm "gosec_${GOSEC_VERSION}_linux_amd64.tar.gz"
 
-# Install the Product Delegation Server (PDS)
-RUN cd /pds && \
+# Install the SecHub Product Delegation Server (PDS)
+RUN cd "$PDS_FOLDER" && \
     # download checksum file
     wget --no-verbose "https://github.com/Daimler/sechub/releases/download/v$PDS_VERSION-pds/sechub-pds-$PDS_VERSION.jar.sha256sum" && \
     # download pds
     wget --no-verbose "https://github.com/Daimler/sechub/releases/download/v$PDS_VERSION-pds/sechub-pds-$PDS_VERSION.jar" && \
     # verify that the checksum and the checksum of the file are same
     sha256sum --check sechub-pds-$PDS_VERSION.jar.sha256sum
-
-# Copy run script into container
-COPY run.sh /run.sh
-
-# Copy scripts
-COPY gosec.sh $SCRIPT_FOLDER/gosec.sh
-COPY gosec_mock.sh $SCRIPT_FOLDER/gosec_mock.sh
-
-# Switch back to root
-USER root
-
-# Set execute permissions for scripts
-RUN chmod +x /run.sh $SCRIPT_FOLDER/gosec.sh $SCRIPT_FOLDER/gosec_mock.sh
 
 # Switch from root to non-root user
 USER "$USER"

--- a/sechub-pds-solutions/gosec/docker/GoSec-Ubuntu.dockerfile
+++ b/sechub-pds-solutions/gosec/docker/GoSec-Ubuntu.dockerfile
@@ -7,6 +7,9 @@ FROM ${BASE_IMAGE}
 # The remaining arguments need to be placed after the `FROM`
 # See: https://ryandaniels.ca/blog/docker-dockerfile-arg-from-arg-trouble/
 
+# User
+ENV USER="gosec"
+
 # Folders
 ARG PDS_FOLDER="/pds"
 ARG SCRIPT_FOLDER="/scripts"
@@ -32,12 +35,12 @@ ENV SHARED_VOLUME_UPLOAD_DIR="$SHARED_VOLUMES/uploads"
 # non-root user
 # using fixed group and user ids
 # gosec needs a home directory for the cache
-RUN groupadd --gid 2323 gosec \
-     && useradd --uid 2323 --no-log-init --create-home --gid gosec gosec
+RUN groupadd --gid 2323 "$USER" \
+     && useradd --uid 2323 --no-log-init --create-home --gid "$USER" "$USER"
 
 # Create folders & change owner of folders
 RUN mkdir --parents "$PDS_FOLDER" "$SCRIPT_FOLDER" "$TOOL_FOLDER" "$WORKSPACE" "$DOWNLOAD_FOLDER" "MOCK_FOLDER" "$SHARED_VOLUME_UPLOAD_DIR" && \
-    chown --recursive gosec:gosec "$DOWNLOAD_FOLDER" "$TOOL_FOLDER" "$WORKSPACE" "$SCRIPT_FOLDER" "$PDS_FOLDER" "$SHARED_VOLUMES"
+    chown --recursive "$USER:$USER" "$DOWNLOAD_FOLDER" "$TOOL_FOLDER" "$WORKSPACE" "$SCRIPT_FOLDER" "$PDS_FOLDER" "$SHARED_VOLUMES"
 
 # Update image and install dependencies
 ENV DEBIAN_FRONTEND noninteractive
@@ -63,7 +66,7 @@ RUN cd "$DOWNLOAD_FOLDER" && \
     echo 'export PATH="/usr/local/go/bin:$PATH":' >> /root/.bashrc
 
 # Switch from root to non-root user
-USER gosec
+USER "$USER"
 
 # Copy mock file
 COPY mock.sarif.json "$MOCK_FOLDER"/mock.sarif.json
@@ -105,14 +108,11 @@ COPY gosec_mock.sh $SCRIPT_FOLDER/gosec_mock.sh
 # Switch back to root
 USER root
 
-# Change owner of run.sh
-RUN chown gosec:gosec /run.sh 
-
 # Set execute permissions for scripts
 RUN chmod +x /run.sh $SCRIPT_FOLDER/gosec.sh $SCRIPT_FOLDER/gosec_mock.sh
 
 # Switch from root to non-root user
-USER gosec
+USER "$USER"
 
 # Set workspace
 WORKDIR "$WORKSPACE"

--- a/sechub-pds-solutions/gosec/docker/mock.sarif.json
+++ b/sechub-pds-solutions/gosec/docker/mock.sarif.json
@@ -131,8 +131,8 @@
 										"guid": "93d834a1-2cc5-38db-837f-66dfc7d711cc",
 										"id": "798",
 										"toolComponent": {
-											"guid": "f2856fc0-85b7-373f-83e7-6f8582243547",
-											"name": "CWE"
+										"guid": "f2856fc0-85b7-373f-83e7-6f8582243547",
+										"name": "CWE"
 										}
 									}
 								}
@@ -169,8 +169,8 @@
 										"guid": "6bd55435-166c-3594-bc06-5e0dea916067",
 										"id": "89",
 										"toolComponent": {
-											"guid": "f2856fc0-85b7-373f-83e7-6f8582243547",
-											"name": "CWE"
+										"guid": "f2856fc0-85b7-373f-83e7-6f8582243547",
+										"name": "CWE"
 										}
 									}
 								}
@@ -180,14 +180,14 @@
 							}
 						}
 					],
-					"semanticVersion": "2.8.0",
+					"semanticVersion": "2.9.5",
 					"supportedTaxonomies": [
 						{
 							"guid": "f2856fc0-85b7-373f-83e7-6f8582243547",
 							"name": "CWE"
 						}
 					],
-					"version": "2.8.0"
+					"version": "2.9.5"
 				}
 			}
 		}


### PR DESCRIPTION
Upgrade GoSec and refactor docker files

- Upgrade GoSec to 2.9.5
- Add a new mock.sarif.json file generated by GoSec 2.9.5
- Refactor dockerfiles
- Add `wget` command to download checksum for PDS
- Add `--remove-orphans` to build command
- No verbose output of wget

closes: #921 